### PR TITLE
Add context search to Avalonia indexer

### DIFF
--- a/GPTExporterIndexerAvalonia/App.axaml
+++ b/GPTExporterIndexerAvalonia/App.axaml
@@ -1,0 +1,8 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="GPTExporterIndexerAvalonia.App"
+             RequestedThemeVariant="Light">
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>

--- a/GPTExporterIndexerAvalonia/App.axaml.cs
+++ b/GPTExporterIndexerAvalonia/App.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace GPTExporterIndexerAvalonia;
+
+public partial class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new Views.MainWindow();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
+++ b/GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.3.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.0" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.0" />
+  </ItemGroup>
+</Project>

--- a/GPTExporterIndexerAvalonia/Helpers/AdvancedIndexer.cs
+++ b/GPTExporterIndexerAvalonia/Helpers/AdvancedIndexer.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace GPTExporterIndexerAvalonia.Helpers;
+
+public class SearchResult
+{
+    public required string File { get; init; }
+    public List<string> Snippets { get; init; } = new();
+}
+
+public static class AdvancedIndexer
+{
+    private static readonly Regex TokenPattern = new("[A-Za-z0-9]+", RegexOptions.Compiled);
+
+    private class Index
+    {
+        public Dictionary<string, HashSet<string>> Tokens { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, FileDetail> Files { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private class FileDetail
+    {
+        public string Filename { get; set; } = string.Empty;
+        public long Modified { get; set; }
+    }
+
+    public static void BuildIndex(string folderPath, string indexPath)
+    {
+        var tokens = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        var files = new Dictionary<string, FileDetail>(StringComparer.OrdinalIgnoreCase);
+        foreach (var file in Directory.EnumerateFiles(folderPath, "*", SearchOption.AllDirectories))
+        {
+            var ext = Path.GetExtension(file).ToLowerInvariant();
+            if (ext != ".txt" && ext != ".json" && ext != ".md")
+                continue;
+            string text;
+            try { text = File.ReadAllText(file); } catch { continue; }
+
+            var relative = Path.GetRelativePath(folderPath, file);
+            files[relative] = new FileDetail
+            {
+                Filename = Path.GetFileName(file),
+                Modified = File.GetLastWriteTimeUtc(file).Ticks
+            };
+
+            foreach (Match m in TokenPattern.Matches(text))
+            {
+                var token = m.Value.ToLowerInvariant();
+                if (!tokens.TryGetValue(token, out var set))
+                {
+                    set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    tokens[token] = set;
+                }
+                set.Add(relative);
+            }
+        }
+        var index = new Index { Tokens = tokens, Files = files };
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        File.WriteAllText(indexPath, JsonSerializer.Serialize(index, options));
+    }
+
+    public static IEnumerable<SearchResult> Search(string indexPath, string phrase, int contextLines = 1)
+    {
+        if (!File.Exists(indexPath) || string.IsNullOrWhiteSpace(phrase))
+            yield break;
+        var index = JsonSerializer.Deserialize<Index>(File.ReadAllText(indexPath));
+        if (index == null)
+            yield break;
+        var tokens = phrase.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        HashSet<string>? result = null;
+        foreach (var token in tokens)
+        {
+            if (!index.Tokens.TryGetValue(token.ToLowerInvariant(), out var set))
+                set = new HashSet<string>();
+            result = result == null ? new HashSet<string>(set) : new HashSet<string>(result.Intersect(set));
+        }
+        if (result == null)
+            yield break;
+        foreach (var rel in result)
+        {
+            var fullPath = Path.Combine(Path.GetDirectoryName(indexPath)!, rel);
+            var snippets = ExtractSnippets(fullPath, phrase, contextLines);
+            yield return new SearchResult { File = rel, Snippets = snippets };
+        }
+    }
+
+    private static List<string> ExtractSnippets(string filePath, string phrase, int context)
+    {
+        var snippets = new List<string>();
+        string[] lines;
+        try { lines = File.ReadAllLines(filePath); } catch { return snippets; }
+        var lowerPhrase = phrase.ToLowerInvariant();
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].ToLowerInvariant().Contains(lowerPhrase))
+            {
+                var start = Math.Max(0, i - context);
+                var end = Math.Min(lines.Length, i + context + 1);
+                snippets.Add(string.Join("\n", lines[start..end]));
+            }
+        }
+        return snippets;
+    }
+}

--- a/GPTExporterIndexerAvalonia/Program.cs
+++ b/GPTExporterIndexerAvalonia/Program.cs
@@ -1,0 +1,19 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.ReactiveUI;
+
+namespace GPTExporterIndexerAvalonia;
+
+internal class Program
+{
+    public static void Main(string[] args)
+    {
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    }
+
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .LogToTrace()
+            .UseReactiveUI();
+}

--- a/GPTExporterIndexerAvalonia/ViewModels/MainWindowViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,45 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using GPTExporterIndexerAvalonia.Helpers;
+using System.Collections.ObjectModel;
+
+namespace GPTExporterIndexerAvalonia.ViewModels;
+
+public partial class MainWindowViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string _indexFolder = string.Empty;
+
+    [ObservableProperty]
+    private string _status = string.Empty;
+
+    [ObservableProperty]
+    private string _query = string.Empty;
+
+    public ObservableCollection<string> Results { get; } = new();
+
+    [RelayCommand]
+    private void BuildIndex()
+    {
+        if (string.IsNullOrWhiteSpace(IndexFolder))
+        {
+            Status = "Select a folder";
+            return;
+        }
+        var indexPath = System.IO.Path.Combine(IndexFolder, "index.json");
+        Status = "Building...";
+        AdvancedIndexer.BuildIndex(IndexFolder, indexPath);
+        Status = $"Index built at {indexPath}";
+    }
+
+    [RelayCommand]
+    private void Search()
+    {
+        Results.Clear();
+        var indexPath = System.IO.Path.Combine(IndexFolder, "index.json");
+        foreach (var result in AdvancedIndexer.Search(indexPath, Query))
+        {
+            Results.Add($"{result.File}: {string.Join(" | ", result.Snippets)}");
+        }
+    }
+}

--- a/GPTExporterIndexerAvalonia/Views/MainWindow.axaml
+++ b/GPTExporterIndexerAvalonia/Views/MainWindow.axaml
@@ -1,0 +1,33 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="https://github.com/avaloniaui"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:GPTExporterIndexerAvalonia.ViewModels"
+        mc:Ignorable="d"
+        x:Class="GPTExporterIndexerAvalonia.Views.MainWindow"
+        Width="600" Height="400"
+        Title="GPT Exporter Indexer">
+    <Design.DataContext>
+        <vm:MainWindowViewModel />
+    </Design.DataContext>
+    <Window.DataContext>
+        <vm:MainWindowViewModel />
+    </Window.DataContext>
+    <TabControl>
+        <TabItem Header="Index">
+            <StackPanel Margin="10" Spacing="5">
+                <TextBlock Text="Folder:" />
+                <TextBox Text="{Binding IndexFolder, UpdateSourceTrigger=PropertyChanged}" />
+                <Button Content="Build Index" Command="{Binding BuildIndexCommand}" />
+                <TextBlock Text="{Binding Status}" />
+            </StackPanel>
+        </TabItem>
+        <TabItem Header="Search">
+            <StackPanel Margin="10" Spacing="5">
+                <TextBox Text="{Binding Query, UpdateSourceTrigger=PropertyChanged}" />
+                <Button Content="Search" Command="{Binding SearchCommand}" />
+                <ListBox Items="{Binding Results}" />
+            </StackPanel>
+        </TabItem>
+    </TabControl>
+</Window>

--- a/GPTExporterIndexerAvalonia/Views/MainWindow.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/MainWindow.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace GPTExporterIndexerAvalonia.Views;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # PhoenixCodex
-The Phoenix Codex  - AmandaMap sorter, indexer, Visualizer. 
+The Phoenix Codex  - AmandaMap sorter, indexer, Visualizer.
+
+## GPTExporterIndexerAvalonia
+
+This repository includes a simple Avalonia application written in C#. It can
+build a token-based search index for `.txt`, `.json` and `.md` files and search
+the resulting index with basic context snippets.


### PR DESCRIPTION
## Summary
- update Avalonia project packages and theme
- replace SimpleIndexer with AdvancedIndexer storing file metadata
- support snippet-based search results in the C# MVVM UI
- document the new Avalonia app in README

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6853f5d7ce7c8332ba3317978ae71ce2