### PR TITLE
Add CodexEngine class library

### DIFF
--- a/CodexEngine/AmandaMapCore/Models.cs
+++ b/CodexEngine/AmandaMapCore/Models.cs
@@ -1,0 +1,16 @@
+namespace CodexEngine.AmandaMapCore.Models
+{
+    public class AmandaMapEntry
+    {
+        public string ID { get; set; }
+        public string Title { get; set; }
+        public DateTime DateTime { get; set; }
+        public string[] Tags { get; set; }
+        public string Content { get; set; }
+        public string SourceFile { get; set; }
+    }
+
+    public class Threshold : AmandaMapEntry { }
+    public class FlameVow : AmandaMapEntry { }
+    public class FieldPulse : AmandaMapEntry { }
+}

--- a/CodexEngine/ChatGPTLogManager/Models.cs
+++ b/CodexEngine/ChatGPTLogManager/Models.cs
@@ -1,0 +1,15 @@
+namespace CodexEngine.ChatGPTLogManager.Models
+{
+    public class ChatMessage
+    {
+        public string Role { get; set; }
+        public string Content { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+
+    public class GPTEntry
+    {
+        public List<ChatMessage> Messages { get; set; }
+        public string SourceFile { get; set; }
+    }
+}

--- a/CodexEngine/CodexEngine.csproj
+++ b/CodexEngine/CodexEngine.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/CodexEngine/ExportEngine/AmandaMapExporter.cs
+++ b/CodexEngine/ExportEngine/AmandaMapExporter.cs
@@ -1,0 +1,15 @@
+namespace CodexEngine.ExportEngine
+{
+    public class AmandaMapExporter
+    {
+        public static void ExportToMarkdown(List<CodexEngine.AmandaMapCore.Models.AmandaMapEntry> entries, string path)
+        {
+            var sb = new System.Text.StringBuilder();
+            foreach (var entry in entries)
+            {
+                sb.AppendLine($"## {entry.Title}\n**Date:** {entry.DateTime}\n**Tags:** {string.Join(", ", entry.Tags)}\n\n{entry.Content}\n\n---\n");
+            }
+            System.IO.File.WriteAllText(path, sb.ToString());
+        }
+    }
+}

--- a/CodexEngine/GrimoireCore/Models.cs
+++ b/CodexEngine/GrimoireCore/Models.cs
@@ -1,0 +1,29 @@
+namespace CodexEngine.GrimoireCore.Models
+{
+    public class Ritual
+    {
+        public string ID { get; set; }
+        public string Title { get; set; }
+        public DateTime DateTime { get; set; }
+        public string[] Tags { get; set; }
+        public string[] Steps { get; set; }
+        public string[] Ingredients { get; set; }
+        public string Content { get; set; }
+    }
+
+    public class Ingredient
+    {
+        public string Name { get; set; }
+        public string Category { get; set; }
+        public string[] Uses { get; set; }
+        public string Notes { get; set; }
+    }
+
+    public class Servitor
+    {
+        public string Name { get; set; }
+        public string Purpose { get; set; }
+        public string VisualDescription { get; set; }
+        public DateTime AnchorDate { get; set; }
+    }
+}

--- a/CodexEngine/RitualForge/Models.cs
+++ b/CodexEngine/RitualForge/Models.cs
@@ -1,0 +1,16 @@
+namespace CodexEngine.RitualForge.Models
+{
+    public class RitualObject
+    {
+        public string Name { get; set; }
+        public string Type { get; set; }
+        public double[] Position { get; set; }
+        public double[] Scale { get; set; }
+        public string[] Tags { get; set; }
+    }
+
+    public class RitualScene
+    {
+        public List<RitualObject> Objects { get; set; } = new();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -23,3 +23,12 @@ dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Rel
 Web assets
 The WebAssets folder contains a small index.html that loads three.js from a CDN.
 This is a placeholder for future visualisation features.
+CodexEngine Library
+-------------------
+The `CodexEngine` folder contains a .NET 8 class library with models and utilities used across the Phoenix Codex tools.
+
+Build it separately with:
+
+```
+dotnet build CodexEngine/CodexEngine.csproj -c Release
+```


### PR DESCRIPTION
## Summary
- add `CodexEngine` .NET class library containing models for AmandaMap, Grimoire entries, ritual scenes, log management and an exporter
- document how to build the new library in README

## Testing
- `python -m compileall -q modules`
- `dotnet build CodexEngine/CodexEngine.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854363704a883328a1ec191da05f308