### PR TITLE
Fix Avalonia MainWindow initialization

### DIFF
--- a/GPTExporterIndexerAvalonia/Views/MainWindow.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/MainWindow.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
 
 namespace GPTExporterIndexerAvalonia.Views;
 
@@ -8,4 +9,6 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
     }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 }


### PR DESCRIPTION
## Summary
- reference Avalonia.Markup.Xaml
- implement InitializeComponent method for MainWindow

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release`
- `dotnet run --project GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj` *(fails: XOpenDisplay failed)*

------
https://chatgpt.com/codex/tasks/task_e_68544a428f088332b4c14efd6e1bc7e3