### PR TITLE
Add Grimoire reader and legacy tool launcher

### DIFF
--- a/GPTExporterIndexerAvalonia/ViewModels/MainWindowViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/MainWindowViewModel.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace GPTExporterIndexerAvalonia.ViewModels;
 
@@ -42,6 +43,12 @@ public partial class MainWindowViewModel : ObservableObject
 
     [ObservableProperty]
     private string _parseStatus = string.Empty;
+
+    [ObservableProperty]
+    private string _bookFile = string.Empty;
+
+    [ObservableProperty]
+    private string _bookContent = string.Empty;
 
     public ObservableCollection<BaseMapEntry> ParsedEntries { get; } = new();
 
@@ -123,5 +130,32 @@ public partial class MainWindowViewModel : ObservableObject
         var exporter = new MarkdownExporter();
         File.WriteAllText(path, exporter.Export(ParsedEntries.ToList()));
         ParseStatus = $"Summary saved to {path}";
+    }
+
+    [RelayCommand]
+    private async Task LoadBook()
+    {
+        if (string.IsNullOrWhiteSpace(BookFile) || !File.Exists(BookFile))
+        {
+            BookContent = "Select a valid book file";
+            return;
+        }
+        BookContent = await File.ReadAllTextAsync(BookFile);
+    }
+
+    [RelayCommand]
+    private void LaunchLegacyTool()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "python",
+                Arguments = "gpt_export_index_tool.py",
+                UseShellExecute = false
+            };
+            Process.Start(psi);
+        }
+        catch { }
     }
 }

--- a/GPTExporterIndexerAvalonia/Views/MainWindow.axaml
+++ b/GPTExporterIndexerAvalonia/Views/MainWindow.axaml
@@ -74,5 +74,20 @@
                 <TextBlock Text="{Binding ParseStatus}" />
             </StackPanel>
         </TabItem>
+        <TabItem Header="Book Reader">
+            <StackPanel Margin="10" Spacing="5">
+                <TextBlock Text="Book File" />
+                <TextBox Text="{Binding BookFile, UpdateSourceTrigger=PropertyChanged}" />
+                <Button Content="Load" Command="{Binding LoadBookCommand}" />
+                <ScrollViewer Height="200">
+                    <TextBlock Text="{Binding BookContent}" TextWrapping="Wrap" />
+                </ScrollViewer>
+            </StackPanel>
+        </TabItem>
+        <TabItem Header="Legacy Tool">
+            <StackPanel Margin="10" Spacing="5">
+                <Button Content="Launch" Command="{Binding LaunchLegacyToolCommand}" />
+            </StackPanel>
+        </TabItem>
     </TabControl>
 </Window>

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Case sensitivity
 Fuzzy matching
 AND/OR logic
 Allows you to open any matching file directly from the search results list.
+Includes a book reader tab for loading Markdown or text files.
+Provides a legacy tool tab to launch the original Python utility.
 Building the Application
 Install the .NET 8 SDK on your system. On Ubuntu, you can do this with the following commands:
 
@@ -38,7 +40,7 @@ After building, start the Avalonia UI with:
 dotnet run --project GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
 ```
 
-The window will display **Index** and **Search** tabs where you can build and search the archive index.
+The window will display **Index**, **Search**, **Parse**, **Book Reader** and **Legacy Tool** tabs where you can build, search and parse the archive, read grimoire files or launch the original tool.
 
 
 Web assets


### PR DESCRIPTION
## Summary
- add book reader and legacy tool tabs to the Avalonia app
- implement ViewModel commands for loading a book file and launching the Python tool
- document new tabs in the README

## Testing
- `python -m py_compile gpt_export_index_tool.py modules/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68548a87498c833288108eda45b0aafa