### PR TITLE
Add simple PDF viewer

### DIFF
--- a/GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
+++ b/GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.3.0" />
@@ -12,6 +13,7 @@
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.0" />
+    <PackageReference Include="Docnet.Core" Version="2.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CodexEngine\CodexEngine.csproj" />

--- a/GPTExporterIndexerAvalonia/Reading/BookReader.cs
+++ b/GPTExporterIndexerAvalonia/Reading/BookReader.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using Avalonia.Media.Imaging;
+using Avalonia;
+using Docnet.Core;
+using Docnet.Core.Models;
+using SkiaSharp;
+using System.Runtime.InteropServices;
+
+namespace GPTExporterIndexerAvalonia.Reading;
+
+public class BookReader
+{
+    public ObservableCollection<Bitmap> Pages { get; } = new();
+
+    public void Load(string path)
+    {
+        Pages.Clear();
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            return;
+
+        using var docReader = DocLib.Instance.GetDocReader(File.ReadAllBytes(path), new PageDimensions(1080, 1920));
+        var pageCount = docReader.GetPageCount();
+        for (var i = 0; i < pageCount; i++)
+        {
+            using var page = docReader.GetPageReader(i);
+            var width = page.GetPageWidth();
+            var height = page.GetPageHeight();
+            var raw = page.GetImage();
+
+            var info = new SKImageInfo(width, height, SKColorType.Bgra8888, SKAlphaType.Premul);
+            var handle = GCHandle.Alloc(raw, GCHandleType.Pinned);
+            try
+            {
+                using var bitmap = new SKBitmap();
+                bitmap.InstallPixels(info, handle.AddrOfPinnedObject(), info.RowBytes);
+                using var image = SKImage.FromBitmap(bitmap);
+                using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+                using var ms = new MemoryStream(data.ToArray());
+                Pages.Add(new Bitmap(ms));
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+    }
+}

--- a/GPTExporterIndexerAvalonia/ViewModels/MainWindowViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/MainWindowViewModel.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using Avalonia.Media.Imaging;
+using GPTExporterIndexerAvalonia.Reading;
 
 namespace GPTExporterIndexerAvalonia.ViewModels;
 
@@ -42,6 +44,13 @@ public partial class MainWindowViewModel : ObservableObject
 
     [ObservableProperty]
     private string _parseStatus = string.Empty;
+
+    [ObservableProperty]
+    private string _documentPath = string.Empty;
+
+    public ObservableCollection<Bitmap> Pages { get; } = new();
+
+    private readonly BookReader _reader = new();
 
     public ObservableCollection<BaseMapEntry> ParsedEntries { get; } = new();
 
@@ -123,5 +132,13 @@ public partial class MainWindowViewModel : ObservableObject
         var exporter = new MarkdownExporter();
         File.WriteAllText(path, exporter.Export(ParsedEntries.ToList()));
         ParseStatus = $"Summary saved to {path}";
+    }
+
+    [RelayCommand]
+    private void LoadDocument()
+    {
+        Pages.Clear();
+        _reader.Load(DocumentPath);
+        foreach (var p in _reader.Pages) Pages.Add(p);
     }
 }

--- a/GPTExporterIndexerAvalonia/Views/MainWindow.axaml
+++ b/GPTExporterIndexerAvalonia/Views/MainWindow.axaml
@@ -74,5 +74,21 @@
                 <TextBlock Text="{Binding ParseStatus}" />
             </StackPanel>
         </TabItem>
+        <TabItem Header="Viewer">
+            <StackPanel Margin="10" Spacing="5">
+                <TextBlock Text="Document" />
+                <TextBox Text="{Binding DocumentPath, UpdateSourceTrigger=PropertyChanged}" />
+                <Button Content="Load" Command="{Binding LoadDocumentCommand}" />
+                <ScrollViewer Height="300">
+                    <ItemsControl Items="{Binding Pages}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Image Source="{Binding}" Stretch="Uniform" Margin="0,5"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </StackPanel>
+        </TabItem>
     </TabControl>
 </Window>


### PR DESCRIPTION
## Summary
- parse PDF pages with new `BookReader` using Docnet.Core
- surface pages in `MainWindowViewModel` and display them in UI
- add a viewer tab in `MainWindow.axaml`
- enable unsafe code for Skia interop

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68548a48a3748332bfbcf8f5ca85df6d