### PR TITLE
Add simple BookViewer control

### DIFF
--- a/GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
+++ b/GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
@@ -8,10 +8,14 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.3.0" />
     <PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
+    <PackageReference Include="Avalonia.HtmlRenderer" Version="11.2.0" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.0" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
+    <PackageReference Include="PdfiumViewer" Version="2.13.0" />
+    <PackageReference Include="VersFx.Formats.Text.Epub" Version="1.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CodexEngine\CodexEngine.csproj" />

--- a/GPTExporterIndexerAvalonia/ViewModels/MainWindowViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/MainWindowViewModel.cs
@@ -38,6 +38,9 @@ public partial class MainWindowViewModel : ObservableObject
     private SearchResult? _selectedResult;
 
     [ObservableProperty]
+    private string _selectedFile = string.Empty;
+
+    [ObservableProperty]
     private string _parseFilePath = string.Empty;
 
     [ObservableProperty]
@@ -123,5 +126,17 @@ public partial class MainWindowViewModel : ObservableObject
         var exporter = new MarkdownExporter();
         File.WriteAllText(path, exporter.Export(ParsedEntries.ToList()));
         ParseStatus = $"Summary saved to {path}";
+    }
+
+    partial void OnSelectedResultChanged(SearchResult? value)
+    {
+        if (value == null)
+        {
+            SelectedFile = string.Empty;
+        }
+        else
+        {
+            SelectedFile = Path.Combine(IndexFolder, value.File);
+        }
     }
 }

--- a/GPTExporterIndexerAvalonia/Views/Controls/BookViewer.axaml
+++ b/GPTExporterIndexerAvalonia/Views/Controls/BookViewer.axaml
@@ -1,0 +1,5 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="GPTExporterIndexerAvalonia.Views.Controls.BookViewer">
+    <ContentControl x:Name="PART_Content" />
+</UserControl>

--- a/GPTExporterIndexerAvalonia/Views/Controls/BookViewer.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/Controls/BookViewer.axaml.cs
@@ -1,0 +1,70 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using PdfiumViewer;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using System.IO;
+using VersFx.Formats.Text.Epub;
+using TheArtOfDev.HtmlRenderer.Avalonia;
+using Avalonia.Media;
+
+namespace GPTExporterIndexerAvalonia.Views.Controls;
+
+public partial class BookViewer : UserControl
+{
+    public static readonly StyledProperty<string?> FilePathProperty =
+        AvaloniaProperty.Register<BookViewer, string?>(nameof(FilePath));
+
+    public string? FilePath
+    {
+        get => GetValue(FilePathProperty);
+        set => SetValue(FilePathProperty, value);
+    }
+
+    private ContentControl? _content;
+
+    public BookViewer()
+    {
+        InitializeComponent();
+        _content = this.FindControl<ContentControl>("PART_Content");
+        this.GetObservable(FilePathProperty).Subscribe(LoadFile);
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private void LoadFile(string? path)
+    {
+        if (string.IsNullOrEmpty(path) || !File.Exists(path))
+        {
+            _content.Content = null;
+            return;
+        }
+
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        if (ext == ".pdf")
+        {
+            var pdfDoc = PdfDocument.Load(path);
+            _content.Content = new PdfViewer { Document = pdfDoc };
+        }
+        else if (ext == ".docx")
+        {
+            using var doc = WordprocessingDocument.Open(path, false);
+            var text = doc.MainDocumentPart?.Document.Body?.InnerText ?? string.Empty;
+            _content.Content = new TextBlock { Text = text, TextWrapping = TextWrapping.Wrap };
+        }
+        else if (ext == ".epub")
+        {
+            var book = EpubReader.ReadBook(path);
+            var firstHtml = book.Content.Html.Values.FirstOrDefault();
+            _content.Content = new HtmlControl { Text = firstHtml?.Content ?? string.Empty };
+        }
+        else
+        {
+            _content.Content = new TextBlock { Text = $"Unsupported: {ext}" };
+        }
+    }
+}

--- a/GPTExporterIndexerAvalonia/Views/MainWindow.axaml
+++ b/GPTExporterIndexerAvalonia/Views/MainWindow.axaml
@@ -15,7 +15,7 @@
         <vm:MainWindowViewModel />
     </Window.DataContext>
 
-    <TabControl>
+    <TabControl xmlns:controls="clr-namespace:GPTExporterIndexerAvalonia.Views.Controls">
         <TabItem Header="Index">
             <StackPanel Margin="10" Spacing="5">
                 <TextBlock Text="Folder:" />
@@ -54,7 +54,7 @@
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>
-                
+                <controls:BookViewer FilePath="{Binding SelectedFile}" Height="200" Margin="0,5"/>
                 <Button Content="Open" Command="{Binding OpenSelectedCommand}" />
             </StackPanel>
         </TabItem>


### PR DESCRIPTION
## Summary
- add packages for Pdf, Docx and Epub viewing
- create `BookViewer` user control
- wire viewer into `MainWindow.axaml`
- surface SelectedFile property in view model

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68548a7e31208332af34d2c2cd322276