### PR TITLE
Switch to cross-platform epub and pdf libraries

### DIFF
--- a/GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
+++ b/GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
@@ -15,8 +15,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.0" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
-    <PackageReference Include="PdfiumViewer" Version="2.13.0" />
-    <PackageReference Include="VersFx.Formats.Text.Epub" Version="1.0.2" />
+    <PackageReference Include="VersOne.Epub" Version="3.3.4" />
     <PackageReference Include="Docnet.Core" Version="2.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/GPTExporterIndexerAvalonia/Views/Controls/BookViewer.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/Controls/BookViewer.axaml.cs
@@ -1,13 +1,14 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
-using PdfiumViewer;
+using GPTExporterIndexerAvalonia.Reading;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using System.IO;
-using VersFx.Formats.Text.Epub;
+using VersOne.Epub;
 using TheArtOfDev.HtmlRenderer.Avalonia;
 using Avalonia.Media;
+using System.Linq;
 
 namespace GPTExporterIndexerAvalonia.Views.Controls;
 
@@ -47,8 +48,19 @@ public partial class BookViewer : UserControl
         var ext = Path.GetExtension(path).ToLowerInvariant();
         if (ext == ".pdf")
         {
-            var pdfDoc = PdfDocument.Load(path);
-            _content.Content = new PdfViewer { Document = pdfDoc };
+            var reader = new BookReader();
+            reader.Load(path);
+            var panel = new StackPanel();
+            foreach (var bmp in reader.Pages)
+            {
+                panel.Children.Add(new Image
+                {
+                    Source = bmp,
+                    Stretch = Stretch.Uniform,
+                    Margin = new Thickness(0, 5)
+                });
+            }
+            _content.Content = new ScrollViewer { Content = panel };
         }
         else if (ext == ".docx")
         {


### PR DESCRIPTION
## Summary
- remove old PdfiumViewer and VersFx.Formats.Text.Epub packages
- add VersOne.Epub package
- display PDFs using Docnet.Core via `BookReader`
- update BookViewer control accordingly

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b3906a3848332a5c705df795d3c43