### PR TITLE
Fix build package reference and object initializers

### DIFF
--- a/GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
+++ b/GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
@@ -10,7 +10,9 @@
     <PackageReference Include="Avalonia" Version="11.3.0" />
     <PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
     <PackageReference Include="Avalonia.HtmlRenderer" Version="11.2.0" />
-    <PackageReference Include="Avalonia.WebView" Version="11.3.0" />
+    <!-- WebView control package was renamed; Avalonia.WebView is provided via
+         WebView.Avalonia -->
+    <PackageReference Include="WebView.Avalonia" Version="11.0.0.1" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.0" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />

--- a/GPTExporterIndexerAvalonia/ViewModels/GrimoireManagerViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/GrimoireManagerViewModel.cs
@@ -37,7 +37,12 @@ public partial class GrimoireManagerViewModel : ObservableObject
     [RelayCommand]
     private void Add()
     {
-        Rituals.Add(new Ritual { Title = "New Ritual" });
+        Rituals.Add(new Ritual
+        {
+            ID = Guid.NewGuid().ToString(),
+            Title = "New Ritual",
+            Content = string.Empty
+        });
         // After adding a ritual, notify the TimelineViewModel to refresh its view
         SharedState.Timeline?.Refresh();
     }
@@ -57,7 +62,11 @@ public partial class GrimoireManagerViewModel : ObservableObject
     [RelayCommand]
     private void AddIngredient()
     {
-        Ingredients.Add(new Ingredient { Name = "New Ingredient" });
+        Ingredients.Add(new Ingredient
+        {
+            Name = "New Ingredient",
+            Category = string.Empty
+        });
     }
 
     [RelayCommand]
@@ -71,7 +80,12 @@ public partial class GrimoireManagerViewModel : ObservableObject
     [RelayCommand]
     private void AddServitor()
     {
-        Servitors.Add(new Servitor { Name = "New Servitor" });
+        Servitors.Add(new Servitor
+        {
+            Name = "New Servitor",
+            Purpose = string.Empty,
+            VisualDescription = string.Empty
+        });
     }
 
     [RelayCommand]

--- a/GPTExporterIndexerAvalonia/ViewModels/RitualBuilderViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/RitualBuilderViewModel.cs
@@ -1,7 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CodexEngine.RitualForge.Models;
-using Avalonia.Controls; // This using directive is likely for WebView, which is a control.
+using Avalonia.Controls; // For common controls
+using AvaloniaWebView; // Provides the WebView control
 using System.Threading.Tasks;
 using System.IO;
 using System;
@@ -24,8 +25,8 @@ public partial class RitualBuilderViewModel : ObservableObject
     [RelayCommand]
     private async Task Save()
     {
-        // Null checks for Builder and WebViewImpl are good practice.
-        if (Builder?.WebViewImpl == null)
+        // Ensure the WebView control has been created
+        if (Builder is null)
             return;
         
         // Execute the JavaScript function to get the scene data.
@@ -39,7 +40,7 @@ public partial class RitualBuilderViewModel : ObservableObject
     private async Task Load()
     {
         // Ensure WebView is ready.
-        if (Builder?.WebViewImpl == null)
+        if (Builder is null)
             return;
         
         // Check if the scene file exists before attempting to load.

--- a/GPTExporterIndexerAvalonia/Views/Controls/BookViewer.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/Controls/BookViewer.axaml.cs
@@ -71,7 +71,8 @@ public partial class BookViewer : UserControl
         else if (ext == ".epub")
         {
             var book = EpubReader.ReadBook(path);
-            var firstHtml = book.Content.Html.Values.FirstOrDefault();
+            // Latest VersOne.Epub exposes Html as a collection with Local/Remote sets
+            var firstHtml = book.Content.Html.Local.FirstOrDefault();
             _content.Content = new HtmlControl { Text = firstHtml?.Content ?? string.Empty };
         }
         else

--- a/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using AvaloniaWebView; // Provides the WebView control
 using GPTExporterIndexerAvalonia.ViewModels;
 
 namespace GPTExporterIndexerAvalonia.Views;


### PR DESCRIPTION
## Summary
- update Avalonia WebView reference
- wire up WebView namespace for RitualBuilder
- adjust EPUB reader logic for newer library
- satisfy `required` properties in Grimoire models

## Testing
- `dotnet --version`
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release` *(fails: Avalonia errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865e343f1848332ac0672bb3d9babcf