### PR TITLE
Add menu with document open in Avalonia UI

### DIFF
--- a/GPTExporterIndexerAvalonia/Views/MainWindow.axaml
+++ b/GPTExporterIndexerAvalonia/Views/MainWindow.axaml
@@ -16,8 +16,15 @@
         <vm:MainWindowViewModel />
     </Window.DataContext>
 
-    <Border Padding="5" BorderThickness="2" BorderBrush="Purple" CornerRadius="8">
-        <TabControl xmlns:controls="clr-namespace:GPTExporterIndexerAvalonia.Views.Controls">
+    <DockPanel>
+        <Menu DockPanel.Dock="Top">
+            <MenuItem Header="_File">
+                <MenuItem Header="_Open Document..." Click="OnOpenDocument" />
+                <MenuItem Header="_Exit" Click="OnExit" />
+            </MenuItem>
+        </Menu>
+        <Border Padding="5" BorderThickness="2" BorderBrush="Purple" CornerRadius="8">
+            <TabControl xmlns:controls="clr-namespace:GPTExporterIndexerAvalonia.Views.Controls">
             <TabItem Header="Index">
                 <StackPanel Margin="10" Spacing="5">
                     <TextBlock Text="Folder:" />
@@ -127,4 +134,5 @@
             </TabItem>
         </TabControl>
     </Border>
+    </DockPanel>
 </Window>

--- a/GPTExporterIndexerAvalonia/Views/MainWindow.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/MainWindow.axaml.cs
@@ -1,5 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using Avalonia.Interactivity;
+using GPTExporterIndexerAvalonia.ViewModels;
 
 namespace GPTExporterIndexerAvalonia.Views;
 
@@ -11,4 +13,18 @@ public partial class MainWindow : Window
     }
 
     private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    private async void OnOpenDocument(object? sender, RoutedEventArgs e)
+    {
+        var dlg = new OpenFileDialog();
+        dlg.Filters.Add(new FileDialogFilter { Name = "Documents", Extensions = { "pdf", "md", "txt" } });
+        var result = await dlg.ShowAsync(this);
+        if (result?.Length > 0 && DataContext is MainWindowViewModel vm)
+        {
+            vm.DocumentPath = result[0];
+            vm.LoadDocumentCommand.Execute(null);
+        }
+    }
+
+    private void OnExit(object? sender, RoutedEventArgs e) => Close();
 }


### PR DESCRIPTION
## Summary
- add a File menu with Open Document and Exit
- hook up menu actions in `MainWindow`

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release -v minimal` *(fails: Unable to find package Avalonia.WebView)*

------
https://chatgpt.com/codex/tasks/task_e_6865e343f1848332ac0672bb3d9babcf