### PR TITLE
Add open entry feature to TagMap

### DIFF
--- a/GPTExporterIndexerAvalonia/Views/TagMapView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/TagMapView.axaml
@@ -26,9 +26,15 @@
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
                                     <Border BorderBrush="Violet" BorderThickness="1" Padding="2" Margin="2">
-                                        <StackPanel>
-                                            <TextBox Text="{Binding Category, UpdateSourceTrigger=PropertyChanged}" />
-                                            <TextBox Text="{Binding Preview, UpdateSourceTrigger=PropertyChanged}" />
+                                        <StackPanel Orientation="Horizontal" Spacing="5">
+                                            <StackPanel>
+                                                <TextBox Width="120" Text="{Binding Category, UpdateSourceTrigger=PropertyChanged}" />
+                                                <TextBox Width="200" Text="{Binding Preview, UpdateSourceTrigger=PropertyChanged}" />
+                                            </StackPanel>
+                                            <TextBox Width="50" Text="{Binding Line, UpdateSourceTrigger=PropertyChanged}" />
+                                            <Button Content="Open"
+                                                    Command="{Binding DataContext.OpenEntryCommand, RelativeSource={RelativeSource AncestorType=TabControl}}"
+                                                    CommandParameter="{Binding}" />
                                         </StackPanel>
                                     </Border>
                                 </DataTemplate>


### PR DESCRIPTION
## Summary
- add `OpenEntryCommand` in `TagMapViewModel` to open an entry's document and scroll to the selected line
- record document name when creating new entries
- expose line editing and open button for each tag entry in `TagMapView`

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667ade324c83329596bccb90976cc7