### PR TITLE
Show TagMap info in search results

### DIFF
--- a/GPTExporterIndexerAvalonia/Views/MainWindow.axaml
+++ b/GPTExporterIndexerAvalonia/Views/MainWindow.axaml
@@ -52,6 +52,8 @@
                             <DataTemplate>
                                 <StackPanel>
                                     <TextBlock Text="{Binding File}" FontWeight="Bold" />
+                                    <TextBlock Text="{Binding Category}" FontStyle="Italic" />
+                                    <TextBlock Text="{Binding Preview}" TextWrapping="Wrap" />
                                     <ItemsControl Items="{Binding Snippets}">
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>


### PR DESCRIPTION
## Summary
- pull TagMap data when indexing files
- attach TagMap category and preview to search results
- show category and preview in search result list

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_68667b450adc83329bac313519a18473