### PR TITLE
Add TagMap importer and file picker

### DIFF
--- a/GPTExporterIndexerAvalonia/Reading/TagMapImporter.cs
+++ b/GPTExporterIndexerAvalonia/Reading/TagMapImporter.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualBasic.FileIO;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using GPTExporterIndexerAvalonia.ViewModels;
+using System.Text.Json;
+
+namespace GPTExporterIndexerAvalonia.Reading;
+
+public static class TagMapImporter
+{
+    public static List<TagMapEntry> Load(string path)
+    {
+        var entries = new List<TagMapEntry>();
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            return entries;
+
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        if (ext == ".json")
+        {
+            try
+            {
+                var json = File.ReadAllText(path);
+                var arr = JsonSerializer.Deserialize<TagMapEntry[]>(json);
+                if (arr != null)
+                    entries.AddRange(arr);
+            }
+            catch { }
+            return entries;
+        }
+
+        if (ext == ".xlsx" || ext == ".xlsm" || ext == ".xltx" || ext == ".xltm")
+            LoadExcel(path, entries);
+        else
+            LoadCsv(path, entries);
+
+        return entries;
+    }
+
+    private static void LoadCsv(string path, List<TagMapEntry> entries)
+    {
+        try
+        {
+            using var parser = new TextFieldParser(path);
+            parser.SetDelimiters(",");
+            parser.HasFieldsEnclosedInQuotes = true;
+            if (parser.EndOfData)
+                return;
+            var headers = parser.ReadFields() ?? Array.Empty<string>();
+            while (!parser.EndOfData)
+            {
+                var fields = parser.ReadFields() ?? Array.Empty<string>();
+                var record = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+                for (int i = 0; i < headers.Length && i < fields.Length; i++)
+                    record[headers[i]] = fields[i];
+                entries.Add(CreateEntry(record));
+            }
+        }
+        catch { }
+    }
+
+    private static void LoadExcel(string path, List<TagMapEntry> entries)
+    {
+        try
+        {
+            using var doc = SpreadsheetDocument.Open(path, false);
+            var workbookPart = doc.WorkbookPart;
+            if (workbookPart == null)
+                return;
+            var sheet = workbookPart.Workbook.Sheets?.Elements<Sheet>().FirstOrDefault();
+            if (sheet == null)
+                return;
+            var worksheetPart = (WorksheetPart)workbookPart.GetPartById(sheet.Id!);
+            var sheetData = worksheetPart.Worksheet.GetFirstChild<SheetData>();
+            if (sheetData == null)
+                return;
+
+            var rows = sheetData.Elements<Row>().ToList();
+            if (rows.Count == 0)
+                return;
+            var shared = workbookPart.SharedStringTablePart?.SharedStringTable;
+
+            var headers = rows[0].Elements<Cell>()
+                .Select(c => GetCellValue(c, shared)?.Trim() ?? string.Empty)
+                .ToList();
+
+            foreach (var row in rows.Skip(1))
+            {
+                var cells = row.Elements<Cell>().ToList();
+                var record = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+                for (int i = 0; i < headers.Count; i++)
+                {
+                    var val = i < cells.Count ? GetCellValue(cells[i], shared) : null;
+                    record[headers[i]] = val;
+                }
+                entries.Add(CreateEntry(record));
+            }
+        }
+        catch { }
+    }
+
+    private static string? GetCellValue(Cell cell, SharedStringTable? shared)
+    {
+        if (cell == null)
+            return null;
+        var value = cell.CellValue?.InnerText;
+        if (cell.DataType?.Value == CellValues.SharedString && int.TryParse(value, out var index))
+            return shared?.ElementAtOrDefault(index)?.InnerText;
+        return value;
+    }
+
+    private static TagMapEntry CreateEntry(Dictionary<string, string?> record)
+    {
+        var entry = new TagMapEntry
+        {
+            Document = record.TryGetValue("Document", out var doc) ? doc ?? string.Empty : string.Empty,
+            Category = record.TryGetValue("Category", out var cat) ? cat ?? string.Empty : string.Empty,
+            Preview = record.TryGetValue("Marker Preview", out var prev) ? prev : null
+        };
+        if (record.TryGetValue("Line #", out var lineStr) && int.TryParse(lineStr, out var line))
+            entry.Line = line;
+        return entry;
+    }
+}
+

--- a/GPTExporterIndexerAvalonia/ViewModels/TagMapViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/TagMapViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Text.Json;
 using System.Linq;
+using GPTExporterIndexerAvalonia.Reading;
 
 namespace GPTExporterIndexerAvalonia.ViewModels;
 
@@ -36,10 +37,7 @@ public partial class TagMapViewModel : ObservableObject
             return;
         try
         {
-            var json = File.ReadAllText(FilePath);
-            var entries = JsonSerializer.Deserialize<TagMapEntry[]>(json);
-            if (entries == null)
-                return;
+            var entries = TagMapImporter.Load(FilePath);
             foreach (var group in entries.GroupBy(e => e.Document))
             {
                 var doc = new TagMapDocument { Name = group.Key ?? string.Empty };

--- a/GPTExporterIndexerAvalonia/Views/TagMapView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/TagMapView.axaml
@@ -8,6 +8,7 @@
     <StackPanel Margin="10" Spacing="5">
         <StackPanel Orientation="Horizontal" Spacing="5">
             <TextBox Width="200" Watermark="TagMap File" Text="{Binding FilePath, UpdateSourceTrigger=PropertyChanged}" />
+            <Button Content="Browse" Click="OnBrowse" />
             <Button Content="Load" Command="{Binding LoadCommand}" />
             <Button Content="Save" Command="{Binding SaveCommand}" />
             <Button Content="Add Doc" Command="{Binding AddDocumentCommand}" />

--- a/GPTExporterIndexerAvalonia/Views/TagMapView.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/TagMapView.axaml.cs
@@ -1,5 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using Avalonia.Interactivity;
+using GPTExporterIndexerAvalonia.ViewModels;
 
 namespace GPTExporterIndexerAvalonia.Views;
 
@@ -13,6 +15,23 @@ public partial class TagMapView : UserControl
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);
+    }
+
+    private async void OnBrowse(object? sender, RoutedEventArgs e)
+    {
+        var dlg = new OpenFileDialog();
+        dlg.Filters.Add(new FileDialogFilter
+        {
+            Name = "TagMap",
+            Extensions = { "csv", "xlsx", "xlsm", "xltx", "xltm", "json" }
+        });
+        var window = this.GetVisualRoot() as Window;
+        var result = await dlg.ShowAsync(window);
+        if (result?.Length > 0 && DataContext is TagMapViewModel vm)
+        {
+            vm.FilePath = result[0];
+            vm.LoadCommand.Execute(null);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- parse TagMap CSV/Excel data with new `TagMapImporter`
- add Browse button for picking a TagMap file
- load TagMap files via importer in `TagMapViewModel`

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667b39db70833283c9f1cbd6f6e7b6