### PR TITLE
Add TagMap file opener

### DIFF
--- a/GPTExporterIndexerAvalonia/Converters/DocEntryConverter.cs
+++ b/GPTExporterIndexerAvalonia/Converters/DocEntryConverter.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using GPTExporterIndexerAvalonia.ViewModels;
+
+namespace GPTExporterIndexerAvalonia.Converters;
+
+public class DocEntryConverter : IMultiValueConverter
+{
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values.Count >= 2 && values[0] is TagMapDocument doc && values[1] is TagMapEntry entry)
+            return (doc, entry);
+        return null;
+    }
+}

--- a/GPTExporterIndexerAvalonia/ViewModels/TagMapViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/TagMapViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Text.Json;
 using System.Linq;
+using System.Text.Json.Serialization;
 
 namespace GPTExporterIndexerAvalonia.ViewModels;
 
@@ -13,6 +14,8 @@ public partial class TagMapEntry
     public string Category { get; set; } = string.Empty;
     public int? Line { get; set; }
     public string? Preview { get; set; }
+    [JsonIgnore]
+    public string? FilePath { get; set; }
 }
 
 public partial class TagMapDocument : ObservableObject
@@ -25,6 +28,9 @@ public partial class TagMapViewModel : ObservableObject
 {
     [ObservableProperty]
     private string _filePath = "tagmap.json";
+
+    [ObservableProperty]
+    private string _selectedSnippet = string.Empty;
 
     public ObservableCollection<TagMapDocument> Documents { get; } = new();
 
@@ -40,11 +46,17 @@ public partial class TagMapViewModel : ObservableObject
             var entries = JsonSerializer.Deserialize<TagMapEntry[]>(json);
             if (entries == null)
                 return;
+            var baseDir = Path.GetDirectoryName(FilePath) ?? string.Empty;
             foreach (var group in entries.GroupBy(e => e.Document))
             {
                 var doc = new TagMapDocument { Name = group.Key ?? string.Empty };
                 foreach (var e in group)
+                {
+                    e.FilePath = Path.IsPathRooted(e.Document)
+                        ? e.Document
+                        : Path.Combine(baseDir, e.Document);
                     doc.Entries.Add(e);
+                }
                 Documents.Add(doc);
             }
         }
@@ -76,7 +88,47 @@ public partial class TagMapViewModel : ObservableObject
     {
         if (document == null)
             return;
-        document.Entries.Add(new TagMapEntry { Category = "General" });
+        var baseDir = Path.GetDirectoryName(FilePath) ?? string.Empty;
+        var entry = new TagMapEntry { Category = "General", Document = document.Name };
+        entry.FilePath = Path.IsPathRooted(entry.Document)
+            ? entry.Document
+            : Path.Combine(baseDir, entry.Document);
+        document.Entries.Add(entry);
+    }
+
+    [RelayCommand]
+    private void OpenEntry(TagMapDocument doc, TagMapEntry entry)
+    {
+        var baseDir = Path.GetDirectoryName(FilePath) ?? string.Empty;
+        entry.FilePath ??= Path.IsPathRooted(entry.Document)
+            ? entry.Document
+            : Path.Combine(baseDir, entry.Document);
+
+        if (!File.Exists(entry.FilePath))
+        {
+            SelectedSnippet = "File not found";
+            return;
+        }
+
+        try
+        {
+            var lines = File.ReadAllLines(entry.FilePath);
+            if (entry.Line.HasValue)
+            {
+                int line = Math.Clamp(entry.Line.Value - 1, 0, lines.Length - 1);
+                int start = Math.Max(0, line - 2);
+                int end = Math.Min(lines.Length - 1, line + 2);
+                SelectedSnippet = string.Join("\n", lines[start..(end + 1)]);
+            }
+            else
+            {
+                SelectedSnippet = string.Join("\n", lines.Take(5));
+            }
+        }
+        catch
+        {
+            SelectedSnippet = string.Empty;
+        }
     }
 }
 

--- a/GPTExporterIndexerAvalonia/Views/TagMapView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/TagMapView.axaml
@@ -1,7 +1,11 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:GPTExporterIndexerAvalonia.ViewModels"
+             xmlns:conv="clr-namespace:GPTExporterIndexerAvalonia.Converters"
              x:Class="GPTExporterIndexerAvalonia.Views.TagMapView">
+    <UserControl.Resources>
+        <conv:DocEntryConverter x:Key="DocEntryConv" />
+    </UserControl.Resources>
     <Design.DataContext>
         <vm:TagMapViewModel />
     </Design.DataContext>
@@ -29,11 +33,24 @@
                                         <StackPanel>
                                             <TextBox Text="{Binding Category, UpdateSourceTrigger=PropertyChanged}" />
                                             <TextBox Text="{Binding Preview, UpdateSourceTrigger=PropertyChanged}" />
+                                            <Button Content="Open">
+                                                <Button.Command>
+                                                    <Binding Path="DataContext.OpenEntryCommand" RelativeSource="{RelativeSource AncestorType=TabControl}" />
+                                                </Button.Command>
+                                                <Button.CommandParameter>
+                                                    <MultiBinding Converter="{StaticResource DocEntryConv}">
+                                                        <Binding Path="DataContext" RelativeSource="{RelativeSource AncestorType=TabItem}" />
+                                                        <Binding />
+                                                    </MultiBinding>
+                                                </Button.CommandParameter>
+                                            </Button>
                                         </StackPanel>
                                     </Border>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
+                        <TextBox Text="{Binding DataContext.SelectedSnippet, RelativeSource={RelativeSource AncestorType=TabControl}}"
+                                 IsReadOnly="True" AcceptsReturn="True" Height="120" TextWrapping="Wrap" />
                     </StackPanel>
                 </DataTemplate>
             </TabControl.ContentTemplate>


### PR DESCRIPTION
## Summary
- compute `TagMapEntry.FilePath` on load
- show context lines in TagMap view
- add converter and command plumbing for opening entries

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -clp:ErrorsOnly` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667b3adbd4833282ed4ce979d99df0