### PR TITLE
Add YAML interpreter tab

### DIFF
--- a/GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
+++ b/GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.3.0" />
     <PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
-    <PackageReference Include="Avalonia.HtmlRenderer" Version="11.2.0" />
-    <PackageReference Include="WebView.Avalonia" Version="11.0.0" />
+    <PackageReference Include="Avalonia.HtmlRenderer" Version="11.3.0" />
+    <PackageReference Include="WebView.Avalonia" Version="11.3.0" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.0" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
@@ -18,6 +18,7 @@
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
     <PackageReference Include="VersOne.Epub" Version="3.3.4" />
     <PackageReference Include="Docnet.Core" Version="2.3.0" />
+    <PackageReference Include="YamlDotNet" Version="13.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CodexEngine\CodexEngine.csproj" />

--- a/GPTExporterIndexerAvalonia/ViewModels/YamlInterpreterViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/YamlInterpreterViewModel.cs
@@ -1,0 +1,74 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.IO;
+using YamlDotNet.Serialization;
+
+namespace GPTExporterIndexerAvalonia.ViewModels;
+
+public class YamlNode : ObservableObject
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Value { get; set; }
+    public ObservableCollection<YamlNode> Children { get; } = new();
+
+    public string Display => string.IsNullOrEmpty(Value) ? Name : $"{Name}: {Value}";
+}
+
+public partial class YamlInterpreterViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string _filePath = string.Empty;
+
+    public ObservableCollection<YamlNode> Items { get; } = new();
+
+    [RelayCommand]
+    private void Load()
+    {
+        Items.Clear();
+        if (string.IsNullOrWhiteSpace(FilePath) || !File.Exists(FilePath))
+            return;
+        try
+        {
+            var text = File.ReadAllText(FilePath);
+            var deserializer = new DeserializerBuilder().Build();
+            var obj = deserializer.Deserialize<object>(text);
+            if (obj != null)
+            {
+                var node = ConvertToNode("root", obj);
+                foreach (var child in node.Children)
+                    Items.Add(child);
+            }
+        }
+        catch { }
+    }
+
+    private static YamlNode ConvertToNode(string name, object value)
+    {
+        var node = new YamlNode { Name = name };
+        switch (value)
+        {
+            case IDictionary<object, object> dict:
+                foreach (var kvp in dict)
+                {
+                    var child = ConvertToNode(kvp.Key.ToString() ?? "", kvp.Value!);
+                    node.Children.Add(child);
+                }
+                break;
+            case IList<object> list:
+                int index = 0;
+                foreach (var item in list)
+                {
+                    var child = ConvertToNode($"[{index}]", item);
+                    node.Children.Add(child);
+                    index++;
+                }
+                break;
+            default:
+                node.Value = value?.ToString();
+                break;
+        }
+        return node;
+    }
+}

--- a/GPTExporterIndexerAvalonia/Views/MainWindow.axaml
+++ b/GPTExporterIndexerAvalonia/Views/MainWindow.axaml
@@ -126,6 +126,9 @@
             <TabItem Header="TagMap">
                 <views:TagMapView />
             </TabItem>
+            <TabItem Header="YAML Interpreter">
+                <views:Yaml.YamlInterpreterView />
+            </TabItem>
             <TabItem Header="Chat Logs">
                 <views:ChatLogView />
             </TabItem>

--- a/GPTExporterIndexerAvalonia/Views/Yaml/YamlInterpreterView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/Yaml/YamlInterpreterView.axaml
@@ -1,0 +1,21 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:GPTExporterIndexerAvalonia.ViewModels"
+             x:Class="GPTExporterIndexerAvalonia.Views.Yaml.YamlInterpreterView">
+    <Design.DataContext>
+        <vm:YamlInterpreterViewModel />
+    </Design.DataContext>
+    <StackPanel Margin="10" Spacing="5">
+        <StackPanel Orientation="Horizontal" Spacing="5">
+            <TextBox Width="220" Watermark="YAML File" Text="{Binding FilePath, UpdateSourceTrigger=PropertyChanged}" />
+            <Button Content="Load" Command="{Binding LoadCommand}" />
+        </StackPanel>
+        <TreeView Items="{Binding Items}">
+            <TreeView.ItemTemplate>
+                <HierarchicalDataTemplate ItemsSource="{Binding Children}">
+                    <TextBlock Text="{Binding Display}" />
+                </HierarchicalDataTemplate>
+            </TreeView.ItemTemplate>
+        </TreeView>
+    </StackPanel>
+</UserControl>

--- a/GPTExporterIndexerAvalonia/Views/Yaml/YamlInterpreterView.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/Yaml/YamlInterpreterView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace GPTExporterIndexerAvalonia.Views.Yaml;
+
+public partial class YamlInterpreterView : UserControl
+{
+    public YamlInterpreterView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ AND/OR logic
 Allows you to open any matching file directly from the search results list.
 Includes a book reader tab for loading Markdown or text files.
 Provides a legacy tool tab to launch the original Python utility.
+TagMap Tab
+-----------
+The **TagMap** tab manages tag entries that point back to lines in your source documents.
+Load a `tagmap.json` file to see each referenced document in its own sub-tab. Within a document you can add new tags, edit the *Category* and *Preview* fields, and then save your changes back to JSON.
+Entries store the document name and an optional line number. Use the built-in **Open Document...** command to jump to the referenced file so you can view the surrounding context before editing.
+
+YAML Interpreter
+----------------
+The **YAML Interpreter** tab lets you load `.yaml` files and inspect their keys and values in a nested tree view.
+Enter a file path, click **Load**, and the entries will be parsed using **YamlDotNet** so you can browse ritual templates directly inside the app.
 Building the Application
 Install the .NET 8 SDK on your system. On Ubuntu, you can do this with the following commands:
 


### PR DESCRIPTION
## Summary
- add YAML interpreter tab to main Avalonia UI
- integrate YamlDotNet and bump WebView/Avalonia.HtmlRenderer versions
- document the new YAML interpreter in README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667b55bda4833292e504834e903d4d