### PR TITLE
Fix build errors and add stubs for missing services

### DIFF
--- a/GPTExporterIndexerAvalonia/App.axaml.cs
+++ b/GPTExporterIndexerAvalonia/App.axaml.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.Messaging;
 using CodexEngine.ExportEngine.Renderers;
 using GPTExporterIndexerAvalonia.Services;
 using GPTExporterIndexerAvalonia.ViewModels;
+using GPTExporterIndexerAvalonia.Views;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 

--- a/GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
+++ b/GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
     <PackageReference Include="VersOne.Epub" Version="3.3.4" />
     <PackageReference Include="Docnet.Core" Version="2.6.0" />
+    <PackageReference Include="WebView.Avalonia.Desktop" Version="11.0.0" />
     <PackageReference Include="YamlDotNet" Version="15.1.2" />
     
     <!-- 

--- a/GPTExporterIndexerAvalonia/Program.cs
+++ b/GPTExporterIndexerAvalonia/Program.cs
@@ -3,7 +3,7 @@
 using Avalonia;
 using Avalonia.ReactiveUI;
 using System;
-using WebView.Avalonia; // FIXED: correct namespace
+using Avalonia.WebView.Desktop;
 
 namespace GPTExporterIndexerAvalonia;
 
@@ -22,5 +22,5 @@ internal class Program
             .UsePlatformDetect()
             .LogToTrace()
             .UseReactiveUI()
-            .UseWebView(); // FIXED: Correctly initialize WebView
+            .UseDesktopWebView();
 }

--- a/GPTExporterIndexerAvalonia/Services/FileParsingService.cs
+++ b/GPTExporterIndexerAvalonia/Services/FileParsingService.cs
@@ -1,0 +1,24 @@
+using CodexEngine.Parsing.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace GPTExporterIndexerAvalonia.Services;
+
+/// <summary>
+/// Simple placeholder implementation of <see cref="IFileParsingService"/>.
+/// </summary>
+public class FileParsingService : IFileParsingService
+{
+    public Task<IEnumerable<BaseMapEntry>> ParseFileAsync(string filePath)
+    {
+        // TODO: Implement parsing logic.
+        IEnumerable<BaseMapEntry> result = new List<BaseMapEntry>();
+        return Task.FromResult(result);
+    }
+
+    public Task<string> ExportSummaryAsync(IEnumerable<BaseMapEntry> entries, string sourceFilePath)
+    {
+        // TODO: Implement summary export.
+        return Task.FromResult(string.Empty);
+    }
+}

--- a/GPTExporterIndexerAvalonia/Services/SearchService.cs
+++ b/GPTExporterIndexerAvalonia/Services/SearchService.cs
@@ -1,0 +1,18 @@
+using GPTExporterIndexerAvalonia.Helpers;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace GPTExporterIndexerAvalonia.Services;
+
+/// <summary>
+/// Basic implementation of <see cref="ISearchService"/> that returns no results.
+/// </summary>
+public class SearchService : ISearchService
+{
+    public Task<IEnumerable<SearchResult>> SearchAsync(string query, SearchOptions options)
+    {
+        // TODO: Replace with real search logic.
+        IEnumerable<SearchResult> empty = new List<SearchResult>();
+        return Task.FromResult(empty);
+    }
+}

--- a/GPTExporterIndexerAvalonia/ViewModels/RitualBuilderViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/RitualBuilderViewModel.cs
@@ -3,7 +3,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CodexEngine.RitualForge.Models;
-using WebView.Avalonia; // FIXED: correct namespace
+using AvaloniaWebView;
 using System.Threading.Tasks;
 using System.IO;
 using System;
@@ -19,7 +19,7 @@ public partial class RitualBuilderViewModel : ObservableObject
     /// <summary>
     /// A reference to the WebView control in the View. This should be set from the code-behind.
     /// </summary>
-    public IWebView? Builder { get; set; }
+    public WebView? Builder { get; set; }
 
     /// <summary>
     /// Defines the path where the ritual scene data will be saved.

--- a/GPTExporterIndexerAvalonia/ViewModels/TagMapViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/TagMapViewModel.cs
@@ -209,8 +209,6 @@ public partial class TagMapViewModel : ObservableObject
                     {
                         IsReadOnly = true,
                         AcceptsReturn = true,
-                        HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
-                        VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
                         Text = File.ReadAllText(path_to_open)
                     };
                     window.Content = textBox;

--- a/GPTExporterIndexerAvalonia/Views/AmandaMapView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/AmandaMapView.axaml
@@ -6,7 +6,7 @@
         <vm:AmandaMapViewModel />
     </Design.DataContext>
     <StackPanel Margin="10" Spacing="5">
-        <TextBox Watermark="File Path" Text="{Binding FilePath, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox Watermark="File Path" Text="{Binding FilePath}" />
         <Button Content="Load" Command="{Binding LoadCommand}" />
         <ScrollViewer Height="250">
             <ItemsControl ItemsSource="{Binding Entries}" >

--- a/GPTExporterIndexerAvalonia/Views/ChatLogView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/ChatLogView.axaml
@@ -7,7 +7,7 @@
     </Design.DataContext>
     <StackPanel Margin="10" Spacing="5">
         <Button Content="Load" Command="{Binding LoadCommand}" />
-        <TextBox Watermark="Filter" Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox Watermark="Filter" Text="{Binding Filter}" />
         <ListBox ItemsSource="{Binding FilteredLogs}">
             <ListBox.ItemTemplate>
                 <DataTemplate>

--- a/GPTExporterIndexerAvalonia/Views/Controls/BookViewer.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/Controls/BookViewer.axaml.cs
@@ -158,8 +158,7 @@ public partial class BookViewer : UserControl
                 IsReadOnly = true,
                 AcceptsReturn = true,
                 TextWrapping = TextWrapping.Wrap,
-                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-                HorizontalScrollBarVisibility = ScrollBarVisibility.Auto
+                // Avalonia handles scroll bars via ScrollViewer. Keep default behaviour.
             };
 
             if (useMonospace)

--- a/GPTExporterIndexerAvalonia/Views/GrimoireManagerView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/GrimoireManagerView.axaml
@@ -14,7 +14,7 @@
             </ListBox.ItemTemplate>
         </ListBox>
         <TextBlock Text="Title" />
-        <TextBox Text="{Binding RitualTitle, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox Text="{Binding RitualTitle}" />
         <Button Content="Add" Command="{Binding AddCommand}" />
         <Button Content="Remove" Command="{Binding RemoveCommand}" />
 
@@ -23,7 +23,7 @@
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal" Spacing="5">
-                        <TextBox Width="150" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />
+                        <TextBox Width="150" Text="{Binding Name}" />
                         <Button Content="X" Command="{Binding DataContext.RemoveIngredientCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" CommandParameter="{Binding}" />
                     </StackPanel>
                 </DataTemplate>
@@ -36,7 +36,7 @@
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal" Spacing="5">
-                        <TextBox Width="150" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />
+                        <TextBox Width="150" Text="{Binding Name}" />
                         <Button Content="X" Command="{Binding DataContext.RemoveServitorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" CommandParameter="{Binding}" />
                     </StackPanel>
                 </DataTemplate>

--- a/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml
@@ -2,13 +2,13 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="https://github.com/avaloniaui"
              xmlns:vm="clr-namespace:GPTExporterIndexerAvalonia.ViewModels"
-            xmlns:wv="clr-namespace:WebView.Avalonia;assembly=WebView.Avalonia"
+            xmlns:wv="clr-namespace:AvaloniaWebView;assembly=Avalonia.WebView"
              x:Class="GPTExporterIndexerAvalonia.Views.RitualBuilderView">
     <Design.DataContext>
         <vm:RitualBuilderViewModel />
     </Design.DataContext>
     <Grid>
-        <wv:WebView Source="/WebAssets/ritual-builder.html" Name="Builder" />
+        <wv:WebView Url="/WebAssets/ritual-builder.html" Name="Builder" />
         <Button Content="Save" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="10" Command="{Binding SaveCommand}" />
     </Grid>
 </UserControl>

--- a/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml.cs
@@ -3,8 +3,8 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity; // FIXED: Added missing using directive
 using Avalonia.Markup.Xaml;
-using WebView.Avalonia; // FIXED: correct namespace
-using Avalonia.VisualTree;
+using AvaloniaWebView;
+using Avalonia;
 using GPTExporterIndexerAvalonia.ViewModels;
 using System;
 
@@ -37,9 +37,8 @@ public partial class RitualBuilderView : UserControl
 
         if (DataContext is RitualBuilderViewModel vm)
         {
-            // Find the WebView control defined in the corresponding .axaml file.
-            // Using the IWebView interface is a good practice for decoupling.
-            var webView = this.FindControl<IWebView>("Builder") 
+            // Locate the WebView control defined in the XAML.
+            var webView = this.FindControl<WebView>("Builder")
                 ?? throw new InvalidOperationException("Could not find a WebView control named 'Builder' in the template.");
             
             // Assign the control instance to the ViewModel property so it can be controlled.

--- a/GPTExporterIndexerAvalonia/Views/TagMapView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/TagMapView.axaml
@@ -11,7 +11,7 @@
     
     <StackPanel Margin="10" Spacing="5">
         <StackPanel Orientation="Horizontal" Spacing="5">
-            <TextBox Width="200" Watermark="TagMap File" Text="{Binding FilePath, UpdateSourceTrigger=PropertyChanged}" />
+            <TextBox Width="200" Watermark="TagMap File" Text="{Binding FilePath}" />
             <Button Content="Browse" Click="OnBrowse" />
             <Button Content="Load" Command="{Binding LoadCommand}" />
             <Button Content="Save" Command="{Binding SaveCommand}" />
@@ -19,8 +19,8 @@
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Spacing="5">
-            <TextBox Width="150" Watermark="Document Filter" Text="{Binding DocumentFilter, UpdateSourceTrigger=PropertyChanged}" />
-            <TextBox Width="150" Watermark="Category Filter" Text="{Binding CategoryFilter, UpdateSourceTrigger=PropertyChanged}" />
+            <TextBox Width="150" Watermark="Document Filter" Text="{Binding DocumentFilter}" />
+            <TextBox Width="150" Watermark="Category Filter" Text="{Binding CategoryFilter}" />
         </StackPanel>
 
         <TabControl ItemsSource="{Binding FilteredDocuments}">
@@ -40,10 +40,10 @@
                                     <Border BorderBrush="DarkCyan" BorderThickness="1" Padding="5" Margin="2">
                                         <StackPanel Orientation="Horizontal" Spacing="5">
                                             <StackPanel Spacing="3">
-                                                <TextBox Width="150" Text="{Binding Category, UpdateSourceTrigger=PropertyChanged}" Watermark="Category"/>
-                                                <TextBox Width="200" Text="{Binding Preview, UpdateSourceTrigger=PropertyChanged}" Watermark="Preview Text"/>
+                                                <TextBox Width="150" Text="{Binding Category}" Watermark="Category"/>
+                                                <TextBox Width="200" Text="{Binding Preview}" Watermark="Preview Text"/>
                                             </StackPanel>
-                                            <TextBox Width="50" Text="{Binding Line, UpdateSourceTrigger=PropertyChanged}" Watermark="Line"/>
+                                            <TextBox Width="50" Text="{Binding Line}" Watermark="Line"/>
                                             
                                             <StackPanel Spacing="3">
                                                 <Button Content="Preview Snippet"

--- a/GPTExporterIndexerAvalonia/Views/TagMapView.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/TagMapView.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Interactivity;
+using Avalonia.VisualTree;
 using GPTExporterIndexerAvalonia.ViewModels;
 
 namespace GPTExporterIndexerAvalonia.Views;

--- a/GPTExporterIndexerAvalonia/Views/Yaml/YamlInterpreterView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/Yaml/YamlInterpreterView.axaml
@@ -7,14 +7,14 @@
     </Design.DataContext>
     <StackPanel Margin="10" Spacing="5">
         <StackPanel Orientation="Horizontal" Spacing="5">
-            <TextBox Width="220" Watermark="YAML File" Text="{Binding FilePath, UpdateSourceTrigger=PropertyChanged}" />
+            <TextBox Width="220" Watermark="YAML File" Text="{Binding FilePath}" />
             <Button Content="Load" Command="{Binding LoadCommand}" />
         </StackPanel>
-        <TreeView Items="{Binding Items}">
+        <TreeView ItemsSource="{Binding Items}">
             <TreeView.ItemTemplate>
-                <HierarchicalDataTemplate ItemsSource="{Binding Children}">
+                <TreeDataTemplate ItemsSource="{Binding Children}">
                     <TextBlock Text="{Binding Display}" />
-                </HierarchicalDataTemplate>
+                </TreeDataTemplate>
             </TreeView.ItemTemplate>
         </TreeView>
     </StackPanel>


### PR DESCRIPTION
## Summary
- correct WebView usage and initialization
- create stub `SearchService` and `FileParsingService`
- update view models and views to compile under .NET 8
- remove unsupported `UpdateSourceTrigger` bindings
- use `TreeDataTemplate` for YAML view

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68686b37d98c83329450183379391695