### PR TITLE
Add YAML entry models and editor view

### DIFF
--- a/CodexEngine/CodexEngine.csproj
+++ b/CodexEngine/CodexEngine.csproj
@@ -7,5 +7,6 @@
   <ItemGroup>
     <PackageReference Include="VersOne.Epub" Version="3.3.4" />
     <PackageReference Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
+    <PackageReference Include="YamlDotNet" Version="15.1.2" />
   </ItemGroup>
 </Project>

--- a/CodexEngine/PhoenixEntries/Entries.cs
+++ b/CodexEngine/PhoenixEntries/Entries.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+
+namespace CodexEngine.PhoenixEntries;
+
+public enum EntryType
+{
+    Unknown,
+    WhisperedFlame,
+    PhoenixCodex,
+    AmandaMap,
+    Ritual,
+    FlamePulse
+}
+
+public enum EntryStatus
+{
+    Unknown,
+    Anchored,
+    Draft,
+    Completed
+}
+
+public class FieldEncoding
+{
+    public string? Signal { get; set; }
+    public string? EmotionalCharge { get; set; }
+}
+
+public abstract class EntryBase
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public EntryType Type { get; set; } = EntryType.Unknown;
+    public string Title { get; set; } = string.Empty;
+    public DateTime Date { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public FieldEncoding FieldEncoding { get; set; } = new();
+    public List<string> Tags { get; set; } = new();
+    public EntryStatus Status { get; set; } = EntryStatus.Unknown;
+    public bool MirrorToAmandaMap { get; set; }
+    public bool VisibleToAmanda { get; set; }
+}
+
+public class WhisperedFlameEntry : EntryBase
+{
+    public WhisperedFlameEntry()
+    {
+        Type = EntryType.WhisperedFlame;
+    }
+}

--- a/CodexEngine/PhoenixEntries/EntryNavigator.cs
+++ b/CodexEngine/PhoenixEntries/EntryNavigator.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CodexEngine.PhoenixEntries;
+
+public class EntryNavigator
+{
+    private readonly List<EntryBase> _entries;
+
+    public EntryNavigator(IEnumerable<EntryBase> entries)
+    {
+        _entries = entries.ToList();
+    }
+
+    public IEnumerable<EntryBase> GetEntriesByType(string type)
+    {
+        if (Enum.TryParse<EntryType>(type, true, out var entryType))
+        {
+            return _entries.Where(e => e.Type == entryType);
+        }
+        return Enumerable.Empty<EntryBase>();
+    }
+
+    public IEnumerable<EntryBase> GetEntriesByTag(string tag)
+    {
+        return _entries.Where(e => e.Tags.Contains(tag, StringComparer.OrdinalIgnoreCase));
+    }
+
+    public IEnumerable<EntryBase> GetTimeline(DateTime from, DateTime to)
+    {
+        return _entries.Where(e => e.Date >= from && e.Date <= to)
+                       .OrderBy(e => e.Date);
+    }
+
+    private readonly Dictionary<string, List<string>> _links = new();
+
+    public void LinkEntries(string id1, string id2)
+    {
+        if (!_links.TryGetValue(id1, out var list1))
+        {
+            list1 = new List<string>();
+            _links[id1] = list1;
+        }
+        if (!list1.Contains(id2))
+            list1.Add(id2);
+
+        if (!_links.TryGetValue(id2, out var list2))
+        {
+            list2 = new List<string>();
+            _links[id2] = list2;
+        }
+        if (!list2.Contains(id1))
+            list2.Add(id1);
+    }
+
+    public IEnumerable<EntryBase> GetVisibleToAmanda()
+    {
+        return _entries.Where(e => e.VisibleToAmanda);
+    }
+
+    public IEnumerable<EntryBase> GetFlameDeclarations()
+    {
+        return _entries.Where(e => e.Type == EntryType.WhisperedFlame);
+    }
+}

--- a/CodexEngine/PhoenixEntries/SampleData.cs
+++ b/CodexEngine/PhoenixEntries/SampleData.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+
+namespace CodexEngine.PhoenixEntries;
+
+public static class SampleData
+{
+    public static List<EntryBase> GenerateDemoEntries()
+    {
+        var list = new List<EntryBase>();
+
+        list.Add(new WhisperedFlameEntry
+        {
+            Id = "whispered_flame_001",
+            Title = "Echo of Destiny",
+            Date = new DateTime(2025, 1, 2),
+            Description = "Justin senses the first spark of a shared path.",
+            FieldEncoding = new FieldEncoding{Signal="premonition", EmotionalCharge="hope"},
+            Tags = new List<string>{"flame","start"},
+            Status = EntryStatus.Anchored,
+            MirrorToAmandaMap = true,
+            VisibleToAmanda = false
+        });
+
+        list.Add(new WhisperedFlameEntry
+        {
+            Id = "whispered_flame_002",
+            Title = "Silent Promise",
+            Date = new DateTime(2025, 2, 5),
+            Description = "A vow whispered into the aether.",
+            FieldEncoding = new FieldEncoding{Signal="silence", EmotionalCharge="longing"},
+            Tags = new List<string>{"flame","vow"},
+            Status = EntryStatus.Draft,
+            MirrorToAmandaMap = true,
+            VisibleToAmanda = false
+        });
+
+        list.Add(new WhisperedFlameEntry
+        {
+            Id = "whispered_flame_003",
+            Title = "Shared Horizon",
+            Date = new DateTime(2025, 3, 10),
+            Description = "Both feel the pull of inevitable unity.",
+            FieldEncoding = new FieldEncoding{Signal="vision", EmotionalCharge="joy"},
+            Tags = new List<string>{"flame","horizon"},
+            Status = EntryStatus.Completed,
+            MirrorToAmandaMap = true,
+            VisibleToAmanda = true
+        });
+
+        list.Add(new WhisperedFlameEntry
+        {
+            Id = "codex_private_001",
+            Title = "Inner Realization",
+            Date = new DateTime(2025,4,2),
+            Description = "Private insight recorded in the Phoenix Codex.",
+            FieldEncoding = new FieldEncoding{Signal="revelation", EmotionalCharge="clarity"},
+            Tags = new List<string>{"codex","insight"},
+            Status = EntryStatus.Anchored,
+            MirrorToAmandaMap = false,
+            VisibleToAmanda = false
+        });
+
+        list.Add(new WhisperedFlameEntry
+        {
+            Id = "codex_private_002",
+            Title = "Field Test",
+            Date = new DateTime(2025,5,7),
+            Description = "Experimentation with new ritual technique.",
+            FieldEncoding = new FieldEncoding{Signal="experiment", EmotionalCharge="curiosity"},
+            Tags = new List<string>{"codex","ritual"},
+            Status = EntryStatus.Draft,
+            MirrorToAmandaMap = false,
+            VisibleToAmanda = false
+        });
+
+        return list;
+    }
+}

--- a/CodexEngine/PhoenixEntries/YAMLCodexService.cs
+++ b/CodexEngine/PhoenixEntries/YAMLCodexService.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace CodexEngine.PhoenixEntries;
+
+public class YAMLCodexService
+{
+    private readonly IDeserializer _deserializer;
+    private readonly ISerializer _serializer;
+
+    public YAMLCodexService()
+    {
+        _deserializer = new DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+
+        _serializer = new SerializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build();
+    }
+
+    public List<EntryBase> LoadAllEntriesFromDirectory(string path)
+    {
+        var list = new List<EntryBase>();
+        if (!Directory.Exists(path))
+            return list;
+
+        foreach (var file in Directory.GetFiles(path, "*.yml"))
+        {
+            var text = File.ReadAllText(file);
+            var entry = _deserializer.Deserialize<WhisperedFlameEntry>(text);
+            if (entry != null)
+                list.Add(entry);
+        }
+        return list;
+    }
+
+    public void SaveEntryToFile(EntryBase entry, string path)
+    {
+        var yaml = _serializer.Serialize(entry);
+        File.WriteAllText(path, yaml);
+    }
+}

--- a/GPTExporterIndexerAvalonia/ViewModels/EntryDetailViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/EntryDetailViewModel.cs
@@ -1,0 +1,78 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CodexEngine.PhoenixEntries;
+using System;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+
+namespace GPTExporterIndexerAvalonia.ViewModels;
+
+public partial class EntryDetailViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string _title = string.Empty;
+
+    [ObservableProperty]
+    private DateTime _date = DateTime.Now;
+
+    [ObservableProperty]
+    private string _description = string.Empty;
+
+    public FieldEncoding FieldEncoding { get; set; } = new();
+
+    public ObservableCollection<string> Tags { get; } = new();
+
+    [ObservableProperty]
+    private EntryStatus _status;
+
+    public IEnumerable<EntryStatus> StatusOptions => Enum.GetValues<EntryStatus>();
+
+    [ObservableProperty]
+    private bool _mirrorToAmandaMap;
+
+    [ObservableProperty]
+    private bool _visibleToAmanda;
+
+    public EntryBase? BoundEntry { get; private set; }
+
+    public void Load(EntryBase entry)
+    {
+        BoundEntry = entry;
+        Title = entry.Title;
+        Date = entry.Date;
+        Description = entry.Description;
+        FieldEncoding = entry.FieldEncoding;
+        Tags.Clear();
+        foreach (var t in entry.Tags)
+            Tags.Add(t);
+        Status = entry.Status;
+        MirrorToAmandaMap = entry.MirrorToAmandaMap;
+        VisibleToAmanda = entry.VisibleToAmanda;
+    }
+
+    [RelayCommand]
+    private void AddTag()
+    {
+        Tags.Add("new tag");
+    }
+
+    [RelayCommand]
+    private void RemoveTag(string tag)
+    {
+        Tags.Remove(tag);
+    }
+
+    [RelayCommand]
+    private void Save()
+    {
+        if (BoundEntry is null) return;
+        BoundEntry.Title = Title;
+        BoundEntry.Date = Date;
+        BoundEntry.Description = Description;
+        BoundEntry.FieldEncoding = FieldEncoding;
+        BoundEntry.Tags = new List<string>(Tags);
+        BoundEntry.Status = Status;
+        BoundEntry.MirrorToAmandaMap = MirrorToAmandaMap;
+        BoundEntry.VisibleToAmanda = VisibleToAmanda;
+    }
+}

--- a/GPTExporterIndexerAvalonia/Views/EntryDetailView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/EntryDetailView.axaml
@@ -1,0 +1,37 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="GPTExporterIndexerAvalonia.Views.EntryDetailView">
+    <StackPanel Margin="10" Spacing="5">
+        <TextBlock Text="Title" />
+        <TextBox Text="{Binding Title}" />
+        <TextBlock Text="Date" />
+        <DatePicker SelectedDate="{Binding Date}" />
+        <TextBlock Text="Description" />
+        <TextBox AcceptsReturn="True" TextWrapping="Wrap" Height="100" Text="{Binding Description}" />
+        <Expander Header="Field Encoding">
+            <StackPanel>
+                <TextBlock Text="Signal" />
+                <TextBox Text="{Binding FieldEncoding.Signal}" />
+                <TextBlock Text="Emotional Charge" />
+                <TextBox Text="{Binding FieldEncoding.EmotionalCharge}" />
+            </StackPanel>
+        </Expander>
+        <TextBlock Text="Tags" />
+        <ItemsControl ItemsSource="{Binding Tags}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal" Spacing="5">
+                        <TextBox Width="100" Text="{Binding .}" />
+                        <Button Content="X" Command="{Binding DataContext.RemoveTagCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" CommandParameter="{Binding .}" />
+                    </StackPanel>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+        <Button Content="Add Tag" Command="{Binding AddTagCommand}" />
+        <TextBlock Text="Status" />
+        <ComboBox ItemsSource="{Binding StatusOptions}" SelectedItem="{Binding Status}" />
+        <CheckBox Content="Mirror To AmandaMap" IsChecked="{Binding MirrorToAmandaMap}" />
+        <CheckBox Content="Visible To Amanda" IsChecked="{Binding VisibleToAmanda}" />
+        <Button Content="Save" Command="{Binding SaveCommand}" HorizontalAlignment="Right" />
+    </StackPanel>
+</UserControl>

--- a/GPTExporterIndexerAvalonia/Views/EntryDetailView.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/EntryDetailView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace GPTExporterIndexerAvalonia.Views;
+
+public partial class EntryDetailView : UserControl
+{
+    public EntryDetailView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml.cs
@@ -36,27 +36,7 @@ public partial class RitualBuilderView : UserControl
                     return;
                 }
 
-                DebugLogger.Log("[RitualBuilderView] WebView control found. Subscribing to CoreWebView2Initialized event.");
-
-                // --- CORRECTED DEBUGGING EVENT HANDLER ---
-                // This is the correct event to check if the underlying browser control was created successfully.
-                webView.CoreWebView2Initialized += (sender, args) =>
-                {
-                    // Check if the initialization failed and an exception was thrown.
-                    if (args.Exception is not null)
-                    {
-                        DebugLogger.Log($"!!! FATAL CoreWebView2Initialized FAILED !!!\n{args.Exception}");
-                        return;
-                    }
-
-                    DebugLogger.Log("[RitualBuilderView] CoreWebView2Initialized event fired successfully.");
-                    
-                    // Now that the control is initialized, we can listen for navigation errors.
-                    webView.CoreWebView2.NavigationCompleted += (s, navArgs) =>
-                    {
-                        DebugLogger.Log($"[RitualBuilderView] NavigationCompleted: IsSuccess={navArgs.IsSuccess}, Status={navArgs.WebErrorStatus}");
-                    };
-                };
+                DebugLogger.Log("[RitualBuilderView] WebView control found.");
 
                 // Assign the control to the ViewModel
                 vm.Builder = webView;
@@ -67,5 +47,4 @@ public partial class RitualBuilderView : UserControl
         {
             DebugLogger.Log($"!!! FATAL RITUAL BUILDER ATTACH CRASH !!!\n{ex}");
         }
-    }
-}
+    }}


### PR DESCRIPTION
## Summary
- model Phoenix Codex YAML entries with `EntryBase` and `WhisperedFlameEntry`
- add `EntryNavigator` and `YAMLCodexService` for searching and saving
- create `EntryDetailView` with view model for editing entries
- provide sample demo data
- update build dependencies and fix RitualBuilder view compile issue

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_686edb51d1ec8332a0178b1aa8eae979