### PR TITLE
Improve ritual builder error handling

### DIFF
--- a/GPTExporterIndexerAvalonia/App.axaml
+++ b/GPTExporterIndexerAvalonia/App.axaml
@@ -1,6 +1,7 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:GPTExporterIndexerAvalonia"
+             xmlns:converters="clr-namespace:GPTExporterIndexerAvalonia.Converters"
              x:Class="GPTExporterIndexerAvalonia.App"
              RequestedThemeVariant="Dark">
     <!--
@@ -9,6 +10,7 @@
     -->
     <Application.Resources>
         <local:ViewLocator x:Key="ViewLocator"/>
+        <converters:StringNullOrEmptyToBoolConverter x:Key="StringNullOrEmptyToBoolConverter"/>
     </Application.Resources>
     
     <Application.Styles>

--- a/GPTExporterIndexerAvalonia/Converters/StringNullOrEmptyToBoolConverter.cs
+++ b/GPTExporterIndexerAvalonia/Converters/StringNullOrEmptyToBoolConverter.cs
@@ -1,0 +1,23 @@
+using Avalonia.Data.Converters;
+using System;
+
+namespace GPTExporterIndexerAvalonia.Converters
+{
+    /// <summary>
+    /// Converts a string to a boolean for bindings like IsVisible.
+    /// Returns true when the string is not null or empty.
+    /// </summary>
+    public class StringNullOrEmptyToBoolConverter : IValueConverter
+    {
+        public object Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+        {
+            var str = value as string;
+            return !string.IsNullOrEmpty(str);
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/GPTExporterIndexerAvalonia/ViewModels/RitualBuilderViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/RitualBuilderViewModel.cs
@@ -22,6 +22,13 @@ public partial class RitualBuilderViewModel : ObservableObject
     public WebView? Builder { get; set; }
 
     /// <summary>
+    /// Holds any error message that occurs during initialization so
+    /// the View can display it to the user instead of silently crashing.
+    /// </summary>
+    [ObservableProperty]
+    private string? _errorMessage;
+
+    /// <summary>
     /// Defines the path where the ritual scene data will be saved.
     //  Using a property for the path is more flexible than hardcoding it.
     /// </summary>

--- a/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml
@@ -11,5 +11,10 @@
     <Grid>
         <wv:WebView Url="avares://GPTExporterIndexerAvalonia/WebAssets/ritual-builder.html" Name="Builder" />
         <Button Content="Save" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="10" Command="{Binding SaveCommand}" />
+        <!-- Display any initialization error -->
+        <TextBlock Text="{Binding ErrorMessage}" Background="#AA000000" Foreground="White"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                   TextWrapping="Wrap" Padding="10"
+                   IsVisible="{Binding ErrorMessage, Converter={StaticResource StringNullOrEmptyToBoolConverter}}"/>
     </Grid>
 </UserControl>

--- a/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml.cs
@@ -46,5 +46,10 @@ public partial class RitualBuilderView : UserControl
         catch (Exception ex)
         {
             DebugLogger.Log($"!!! FATAL RITUAL BUILDER ATTACH CRASH !!!\n{ex}");
+            if (DataContext is RitualBuilderViewModel vm)
+            {
+                vm.ErrorMessage = $"Failed to initialize ritual builder: {ex.Message}";
+            }
         }
-    }}
+    }
+}


### PR DESCRIPTION
## Summary
- add `ErrorMessage` property to RitualBuilderViewModel so that UI can display initialization failures
- display error text over RitualBuilderView when present
- new `StringNullOrEmptyToBoolConverter` for binding ErrorMessage to `IsVisible`
- register the converter in App resources
- log and surface exceptions during `OnAttachedToVisualTree`

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686ef688791c833290e1797b13873bda