### PR TITLE
Update .NET SDK notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ The **YAML Interpreter** tab lets you load `.yaml` files and inspect their keys 
 Enter a file path, click **Load**, and the entries will be parsed using **YamlDotNet** so you can browse ritual templates directly inside the app.
 
 Building the Application
-Install the .NET 8 SDK on your system. On Ubuntu, you can do this with the following commands:
+Both **GPTExporterIndexerAvalonia** and **CodexEngine** require the .NET&nbsp;8 SDK. Make sure it is installed before running `dotnet build` or `dotnet run`.
+Install the SDK on your system. On Ubuntu, you can do this with the following commands:
 
 Bash
 


### PR DESCRIPTION
## Summary
- clarify that the .NET 8 SDK is required for `GPTExporterIndexerAvalonia` and `CodexEngine`
- remind users to install the SDK before running `dotnet build` or `dotnet run`

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release` *(fails: WebView namespace missing)*
- `dotnet build CodexEngine/CodexEngine.csproj -c Release`
- `dotnet run --project GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872d27a1cfc8332b3049ab3a0b4e983