### PR TITLE
Make Ritual observable

### DIFF
--- a/CodexEngine/CodexEngine.csproj
+++ b/CodexEngine/CodexEngine.csproj
@@ -8,5 +8,6 @@
     <PackageReference Include="VersOne.Epub" Version="3.3.4" />
     <PackageReference Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
     <PackageReference Include="YamlDotNet" Version="15.1.2" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
   </ItemGroup>
 </Project>

--- a/CodexEngine/GrimoireCore/Models.cs
+++ b/CodexEngine/GrimoireCore/Models.cs
@@ -1,35 +1,41 @@
-namespace CodexEngine.GrimoireCore.Models
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace CodexEngine.GrimoireCore.Models;
+
+public partial class Ritual : ObservableObject
 {
-    public class Ritual
-    {
-        public required string ID { get; set; }
-        public required string Title { get; set; }
-        public DateTime DateTime { get; set; }
-        public string[] Tags { get; set; } = Array.Empty<string>();
-        public string[] Steps { get; set; } = Array.Empty<string>();
-        public string[] Ingredients { get; set; } = Array.Empty<string>();
-        public required string Content { get; set; }
-        
-        // This property was missing
-        public string? Purpose { get; set; }
-        
-        // This property was added correctly in the last step
-        public string? Outcome { get; set; }
-    }
+    public required string ID { get; set; }
 
-    public class Ingredient
-    {
-        public required string Name { get; set; }
-        public required string Category { get; set; }
-        public string[] Uses { get; set; } = Array.Empty<string>();
-        public string? Notes { get; set; }
-    }
+    [ObservableProperty]
+    private string _title = string.Empty;
 
-    public class Servitor
-    {
-        public required string Name { get; set; }
-        public required string Purpose { get; set; }
-        public required string VisualDescription { get; set; }
-        public DateTime AnchorDate { get; set; }
-    }
+    [ObservableProperty]
+    private DateTime _dateTime;
+
+    public string[] Tags { get; set; } = Array.Empty<string>();
+    public string[] Steps { get; set; } = Array.Empty<string>();
+    public string[] Ingredients { get; set; } = Array.Empty<string>();
+    public required string Content { get; set; }
+
+    public string? Purpose { get; set; }
+
+    public string? Outcome { get; set; }
+
+    public Ritual() { }
+}
+
+public class Ingredient
+{
+    public required string Name { get; set; }
+    public required string Category { get; set; }
+    public string[] Uses { get; set; } = Array.Empty<string>();
+    public string? Notes { get; set; }
+}
+
+public class Servitor
+{
+    public required string Name { get; set; }
+    public required string Purpose { get; set; }
+    public required string VisualDescription { get; set; }
+    public DateTime AnchorDate { get; set; }
 }

--- a/GPTExporterIndexerAvalonia/ViewModels/GrimoireManagerViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/GrimoireManagerViewModel.cs
@@ -30,22 +30,6 @@ public partial class GrimoireManagerViewModel : ObservableObject, IRecipient<Add
     [ObservableProperty]
     private Ritual? _selectedRitual;
 
-    [ObservableProperty]
-    private string? _ritualTitle;
-
-    partial void OnSelectedRitualChanged(Ritual? value)
-    {
-        RitualTitle = value?.Title;
-    }
-
-    partial void OnRitualTitleChanged(string? value)
-    {
-        if (SelectedRitual != null && value != null)
-        {
-            SelectedRitual.Title = value;
-        }
-    }
-
     // This new method handles the incoming message from the MainWindowViewModel
     public void Receive(AddNewRitualMessage message)
     {

--- a/GPTExporterIndexerAvalonia/Views/GrimoireManagerView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/GrimoireManagerView.axaml
@@ -15,7 +15,7 @@
             </ListBox.ItemTemplate>
         </ListBox>
         <TextBlock Text="Title" />
-        <TextBox Text="{Binding RitualTitle}" />
+        <TextBox Text="{Binding SelectedRitual.Title}" />
         <Button Content="Add" Command="{Binding AddRitualCommand}" />
         <Button Content="Remove" Command="{Binding RemoveRitualCommand}" />
 


### PR DESCRIPTION
## Summary
- make `Ritual` derive from `ObservableObject`
- update CodexEngine project to reference CommunityToolkit.Mvvm
- simplify `GrimoireManagerViewModel` selection handling
- bind ritual title directly in the Grimoire view

## Testing
- `dotnet build CodexEngine/CodexEngine.csproj -v q`
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -v q` *(fails: WebView namespace not found)*

------
https://chatgpt.com/codex/tasks/task_e_687483993288833298d97fb72970fe49