### PR TITLE
Fix WebView namespace and ErrorBoundary imports

### DIFF
--- a/GPTExporterIndexerAvalonia/Views/Controls/ErrorBoundary.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/Controls/ErrorBoundary.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Primitives;
 using Avalonia.Media;
 using System;
 using GPTExporterIndexerAvalonia.Services;
@@ -9,7 +10,7 @@ using Avalonia.LogicalTree;
 
 namespace GPTExporterIndexerAvalonia.Views.Controls
 {
-    public class ErrorBoundary : ContentControl
+    public partial class ErrorBoundary : UserControl
     {
         // FIXED: The method argument is TemplateAppliedEventArgs, not AppliedStyles
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
@@ -22,7 +23,7 @@ namespace GPTExporterIndexerAvalonia.Views.Controls
                 // If the child (e.g., RitualBuilderView) is going to crash,
                 // it will happen here.
                 (Content as ISetLogicalParent)?.SetParent(this);
-                (Content as IControl)?.ApplyTemplate();
+                (Content as Control)?.ApplyTemplate();
             }
             catch (Exception ex)
             {

--- a/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml.cs
@@ -1,8 +1,8 @@
 using Avalonia.Controls;
-using Avalonia.Controls.WebView; // Make sure you have this using statement
+using AvaloniaWebView; // Correct namespace for WebView.Avalonia
 using Avalonia.Markup.Xaml;
 using GPTExporterIndexerAvalonia.ViewModels; // Make sure you have this using statement
-using RitualOS.Services; // Assuming DebugLogger is here
+using GPTExporterIndexerAvalonia.Services;
 using System;
 
 namespace GPTExporterIndexerAvalonia.Views


### PR DESCRIPTION
## Summary
- correct WebView namespace usage in `RitualBuilderView`
- clean up DebugLogger using statement
- add `Controls.Primitives` import for `ErrorBoundary`
- make `ErrorBoundary` class partial and use `Control` cast

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6874837f53fc833297f855ad667f604e