### PR TITLE
Group AmandaMap view by entry type

### DIFF
--- a/GPTExporterIndexerAvalonia/ViewModels/EntryTypeGroup.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/EntryTypeGroup.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using CodexEngine.AmandaMapCore.Models;
+
+namespace GPTExporterIndexerAvalonia.ViewModels;
+
+/// <summary>
+/// Helper class used for grouping AmandaMap entries by their EntryType.
+/// </summary>
+public class EntryTypeGroup
+{
+    public string EntryType { get; }
+    public ObservableCollection<NumberedMapEntry> Entries { get; }
+
+    public EntryTypeGroup(string entryType, IEnumerable<NumberedMapEntry> entries)
+    {
+        EntryType = entryType;
+        Entries = new ObservableCollection<NumberedMapEntry>(entries);
+    }
+}

--- a/GPTExporterIndexerAvalonia/Views/AmandaMapView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/AmandaMapView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:GPTExporterIndexerAvalonia.ViewModels"
+             xmlns:models="clr-namespace:CodexEngine.AmandaMapCore.Models;assembly=CodexEngine"
              x:Class="GPTExporterIndexerAvalonia.Views.AmandaMapView"
              DataContext="{Binding AmandaMapViewModel}">
     <Design.DataContext>
@@ -13,15 +14,20 @@
         </StackPanel>
         <Button Content="Load" Command="{Binding LoadCommand}" />
         <ScrollViewer Height="250">
-            <ItemsControl ItemsSource="{Binding Entries}" >
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
+            <TreeView ItemsSource="{Binding GroupedEntries}">
+                <TreeView.Resources>
+                    <DataTemplate DataType="{x:Type models:NumberedMapEntry}">
                         <Border BorderBrush="Violet" BorderThickness="1" Margin="2" Padding="2">
-                             <TextBlock Text="{Binding Title}" />
+                            <TextBlock Text="{Binding Title}" />
                         </Border>
                     </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
+                </TreeView.Resources>
+                <TreeView.ItemTemplate>
+                    <TreeDataTemplate ItemsSource="{Binding Entries}">
+                        <TextBlock Text="{Binding EntryType}" FontWeight="Bold" />
+                    </TreeDataTemplate>
+                </TreeView.ItemTemplate>
+            </TreeView>
         </ScrollViewer>
     </StackPanel>
 </UserControl>


### PR DESCRIPTION
## Summary
- group AmandaMap entries by their EntryType
- create EntryTypeGroup helper model
- show grouped entries via TreeView and add headers for each entry type

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687483aa1abc833298e7437680ab0304