### PR TITLE
Add ritual date editing

### DIFF
--- a/GPTExporterIndexerAvalonia/ViewModels/GrimoireManagerViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/GrimoireManagerViewModel.cs
@@ -33,9 +33,13 @@ public partial class GrimoireManagerViewModel : ObservableObject, IRecipient<Add
     [ObservableProperty]
     private string? _ritualTitle;
 
+    [ObservableProperty]
+    private DateTime _ritualDate;
+
     partial void OnSelectedRitualChanged(Ritual? value)
     {
         RitualTitle = value?.Title;
+        RitualDate = value?.DateTime ?? DateTime.Now;
     }
 
     partial void OnRitualTitleChanged(string? value)
@@ -43,6 +47,25 @@ public partial class GrimoireManagerViewModel : ObservableObject, IRecipient<Add
         if (SelectedRitual != null && value != null)
         {
             SelectedRitual.Title = value;
+        }
+    }
+
+    partial void OnRitualDateChanged(DateTime value)
+    {
+        if (SelectedRitual != null)
+        {
+            SelectedRitual.DateTime = value;
+            SortRituals();
+        }
+    }
+
+    private void SortRituals()
+    {
+        var sortedRituals = new ObservableCollection<Ritual>(Rituals.OrderBy(r => r.DateTime));
+        Rituals.Clear();
+        foreach (var r in sortedRituals)
+        {
+            Rituals.Add(r);
         }
     }
 

--- a/GPTExporterIndexerAvalonia/Views/GrimoireManagerView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/GrimoireManagerView.axaml
@@ -10,12 +10,17 @@
         <ListBox ItemsSource="{Binding Rituals}" SelectedItem="{Binding SelectedRitual}">
             <ListBox.ItemTemplate>
                 <DataTemplate>
-                    <TextBlock Text="{Binding Title}" />
+                    <StackPanel Orientation="Horizontal" Spacing="5">
+                        <TextBlock Text="{Binding Title}" />
+                        <TextBlock Text="{Binding DateTime, StringFormat='({0:yyyy-MM-dd})'}" Margin="5,0,0,0" />
+                    </StackPanel>
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>
         <TextBlock Text="Title" />
         <TextBox Text="{Binding RitualTitle}" />
+        <TextBlock Text="Date" />
+        <DatePicker SelectedDate="{Binding RitualDate}" />
         <Button Content="Add" Command="{Binding AddRitualCommand}" />
         <Button Content="Remove" Command="{Binding RemoveRitualCommand}" />
 


### PR DESCRIPTION
## Summary
- show ritual dates in the ritual list
- allow editing the selected ritual's date
- automatically re-sort rituals when dates change

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release` *(fails: WebView related build errors)*

------
https://chatgpt.com/codex/tasks/task_e_687483a723fc8332911584a17721c57e