### PR TITLE
Add Spirit management to grimoire

### DIFF
--- a/CodexEngine/GrimoireCore/Models.cs
+++ b/CodexEngine/GrimoireCore/Models.cs
@@ -32,4 +32,12 @@ namespace CodexEngine.GrimoireCore.Models
         public required string VisualDescription { get; set; }
         public DateTime AnchorDate { get; set; }
     }
+
+    public class Spirit
+    {
+        public required string Name { get; set; }
+        public required string Purpose { get; set; }
+        public string? Domain { get; set; }
+        public string? Description { get; set; }
+    }
 }

--- a/GPTExporterIndexerAvalonia/ViewModels/GrimoireManagerViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/GrimoireManagerViewModel.cs
@@ -17,6 +17,7 @@ public partial class GrimoireManagerViewModel : ObservableObject, IRecipient<Add
     public ObservableCollection<Ritual> Rituals { get; } = new();
     public ObservableCollection<Ingredient> Ingredients { get; } = new();
     public ObservableCollection<Servitor> Servitors { get; } = new();
+    public ObservableCollection<Spirit> Spirits { get; } = new();
 
     public GrimoireManagerViewModel(IMessenger messenger)
     {
@@ -108,5 +109,17 @@ public partial class GrimoireManagerViewModel : ObservableObject, IRecipient<Add
     private void RemoveServitor(Servitor? servitor)
     {
         if (servitor != null) { Servitors.Remove(servitor); }
+    }
+
+    [RelayCommand]
+    private void AddSpirit()
+    {
+        Spirits.Add(new Spirit { Name = "New Spirit", Purpose = string.Empty });
+    }
+
+    [RelayCommand]
+    private void RemoveSpirit(Spirit? spirit)
+    {
+        if (spirit != null) { Spirits.Remove(spirit); }
     }
 }

--- a/GPTExporterIndexerAvalonia/Views/GrimoireManagerView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/GrimoireManagerView.axaml
@@ -44,5 +44,18 @@
             </ListBox.ItemTemplate>
         </ListBox>
         <Button Content="Add Servitor" Command="{Binding AddServitorCommand}" />
+
+        <TextBlock Text="Spirits" Margin="0,10,0,0" FontWeight="Bold" />
+        <ListBox ItemsSource="{Binding Spirits}">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal" Spacing="5">
+                        <TextBox Width="150" Text="{Binding Name}" />
+                        <Button Content="X" Command="{Binding DataContext.RemoveSpiritCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" CommandParameter="{Binding}" />
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+        <Button Content="Add Spirit" Command="{Binding AddSpiritCommand}" />
     </StackPanel>
 </UserControl>


### PR DESCRIPTION
## Summary
- add `Spirit` model to GrimoireCore
- manage Spirits in `GrimoireManagerViewModel`
- expose spirit add/remove controls in the Grimoire manager view

## Testing
- `dotnet build CodexEngine/CodexEngine.csproj -c Release`
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release` *(fails: missing WebView dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687483a6457883328923c50204dcb46c