### PR TITLE
Improve error propagation in RitualBuilderViewModel

### DIFF
--- a/GPTExporterIndexerAvalonia/ViewModels/RitualBuilderViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/RitualBuilderViewModel.cs
@@ -49,7 +49,7 @@ public partial class RitualBuilderViewModel : ObservableObject
 
         try
         {
-            // Assumes the JavaScript function 'window.saveScene()' exists in the loaded HTML 
+            // Assumes the JavaScript function 'window.saveScene()' exists in the loaded HTML
             // and returns the scene data as a JSON string.
             var result = await Builder.ExecuteScriptAsync("window.saveScene();");
 
@@ -59,6 +59,7 @@ public partial class RitualBuilderViewModel : ObservableObject
         catch (Exception ex)
         {
             DebugLogger.Log($"Error saving ritual scene: {ex.Message}");
+            ErrorMessage = "Failed to save the ritual scene.";
         }
     }
 
@@ -95,6 +96,7 @@ public partial class RitualBuilderViewModel : ObservableObject
         catch (Exception ex)
         {
             DebugLogger.Log($"Error loading ritual scene: {ex.Message}");
+            ErrorMessage = "Failed to load the ritual scene.";
         }
     }
 }


### PR DESCRIPTION
## Summary
- propagate errors from Save/Load to `ErrorMessage`
- log save/load errors via `DebugLogger`

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_687486e6d99c8332bbca448620d9ebd2