### PR TITLE
Add TagMap loader and UI support for CSV/XLSX

### DIFF
--- a/GPTExporterIndexerAvalonia/Helpers/TagMapLoader.cs
+++ b/GPTExporterIndexerAvalonia/Helpers/TagMapLoader.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using GPTExporterIndexerAvalonia.ViewModels;
+
+namespace GPTExporterIndexerAvalonia.Helpers;
+
+public static class TagMapLoader
+{
+    public static List<TagMapEntry> Load(string path)
+    {
+        var list = new List<TagMapEntry>();
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            return list;
+
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        if (ext == ".xlsx" || ext == ".xlsm" || ext == ".xltx" || ext == ".xltm")
+        {
+            LoadExcel(path, list);
+        }
+        else
+        {
+            LoadCsv(path, list);
+        }
+        return list;
+    }
+
+    private static void LoadCsv(string path, List<TagMapEntry> list)
+    {
+        using var parser = new Microsoft.VisualBasic.FileIO.TextFieldParser(path);
+        parser.SetDelimiters(",");
+        parser.HasFieldsEnclosedInQuotes = true;
+        var headers = parser.ReadFields();
+        if (headers == null)
+            return;
+        while (!parser.EndOfData)
+        {
+            var fields = parser.ReadFields();
+            if (fields == null)
+                continue;
+            var dict = new Dictionary<string, string?>();
+            for (int i = 0; i < headers.Length && i < fields.Length; i++)
+                dict[headers[i]] = fields[i];
+            AddEntry(dict, list);
+        }
+    }
+
+    private static void LoadExcel(string path, List<TagMapEntry> list)
+    {
+        using var doc = SpreadsheetDocument.Open(path, false);
+        var wb = doc.WorkbookPart;
+        if (wb == null)
+            return;
+        var sst = wb.SharedStringTablePart?.SharedStringTable;
+        var sheet = wb.Workbook.Sheets?.GetFirstChild<Sheet>();
+        if (sheet == null)
+            return;
+        var wsPart = (WorksheetPart)wb.GetPartById(sheet.Id!);
+        var rows = wsPart.Worksheet.GetFirstChild<SheetData>()?.Elements<Row>();
+        if (rows == null)
+            return;
+        var rowList = new List<Row>(rows);
+        if (rowList.Count == 0)
+            return;
+        var headers = new List<string>();
+        foreach (var cell in rowList[0].Elements<Cell>())
+            headers.Add(GetCellValue(cell, sst).Trim());
+        for (int i = 1; i < rowList.Count; i++)
+        {
+            var cells = new List<Cell>(rowList[i].Elements<Cell>());
+            var dict = new Dictionary<string, string?>();
+            for (int c = 0; c < headers.Count; c++)
+            {
+                string value = c < cells.Count ? GetCellValue(cells[c], sst) : string.Empty;
+                dict[headers[c]] = value;
+            }
+            AddEntry(dict, list);
+        }
+    }
+
+    private static string GetCellValue(Cell cell, SharedStringTable? sst)
+    {
+        var value = cell.CellValue?.InnerText ?? string.Empty;
+        if (cell.DataType?.Value == CellValues.SharedString && int.TryParse(value, out var idx) && sst != null)
+        {
+            var item = sst.ElementAtOrDefault(idx);
+            if (item != null)
+                return item.InnerText ?? string.Empty;
+        }
+        return value;
+    }
+
+    private static void AddEntry(Dictionary<string, string?> dict, List<TagMapEntry> list)
+    {
+        var entry = new TagMapEntry
+        {
+            Document = dict.GetValueOrDefault("Document") ?? string.Empty,
+            Category = dict.GetValueOrDefault("Category") ?? string.Empty,
+            Preview = dict.GetValueOrDefault("Marker Preview"),
+        };
+        if (int.TryParse(dict.GetValueOrDefault("Line #"), out var line))
+            entry.Line = line;
+        if (DateTime.TryParse(dict.GetValueOrDefault("Date"), out var dt))
+        {
+            // For now Date is not stored in TagMapEntry, but you could extend it
+        }
+        list.Add(entry);
+    }
+}

--- a/GPTExporterIndexerAvalonia/ViewModels/TagMapViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/TagMapViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Text.Json;
 using System.Linq;
+using GPTExporterIndexerAvalonia.Helpers;
 
 namespace GPTExporterIndexerAvalonia.ViewModels;
 
@@ -36,9 +37,18 @@ public partial class TagMapViewModel : ObservableObject
             return;
         try
         {
-            var json = File.ReadAllText(FilePath);
-            var entries = JsonSerializer.Deserialize<TagMapEntry[]>(json);
-            if (entries == null)
+            List<TagMapEntry> entries;
+            var ext = Path.GetExtension(FilePath).ToLowerInvariant();
+            if (ext == ".json")
+            {
+                var json = File.ReadAllText(FilePath);
+                entries = JsonSerializer.Deserialize<TagMapEntry[]>(json)?.ToList() ?? new List<TagMapEntry>();
+            }
+            else
+            {
+                entries = TagMapLoader.Load(FilePath);
+            }
+            if (entries.Count == 0)
                 return;
             foreach (var group in entries.GroupBy(e => e.Document))
             {

--- a/GPTExporterIndexerAvalonia/Views/TagMapView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/TagMapView.axaml
@@ -8,6 +8,7 @@
     <StackPanel Margin="10" Spacing="5">
         <StackPanel Orientation="Horizontal" Spacing="5">
             <TextBox Width="200" Watermark="TagMap File" Text="{Binding FilePath, UpdateSourceTrigger=PropertyChanged}" />
+            <Button Content="Browse" Click="OnBrowse" />
             <Button Content="Load" Command="{Binding LoadCommand}" />
             <Button Content="Save" Command="{Binding SaveCommand}" />
             <Button Content="Add Doc" Command="{Binding AddDocumentCommand}" />

--- a/GPTExporterIndexerAvalonia/Views/TagMapView.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/TagMapView.axaml.cs
@@ -1,5 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using Avalonia.Interactivity;
+using GPTExporterIndexerAvalonia.ViewModels;
 
 namespace GPTExporterIndexerAvalonia.Views;
 
@@ -13,6 +15,19 @@ public partial class TagMapView : UserControl
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);
+    }
+
+    private async void OnBrowse(object? sender, RoutedEventArgs e)
+    {
+        var dlg = new OpenFileDialog();
+        dlg.Filters.Add(new FileDialogFilter { Name = "TagMap", Extensions = { "csv", "xlsx" } });
+        var window = this.GetVisualRoot() as Window;
+        var result = await dlg.ShowAsync(window);
+        if (result?.Length > 0 && DataContext is TagMapViewModel vm)
+        {
+            vm.FilePath = result[0];
+            vm.LoadCommand.Execute(null);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- implement `TagMapLoader` to read TagMap data from CSV or Excel files
- update `TagMapViewModel` to use the new loader
- allow browsing for TagMap files via `OpenFileDialog`
- expose browse button in `TagMapView`

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667ad84798833291016735a1bafdea