### PR TITLE
Handle TagMap import failures

### DIFF
--- a/GPTExporterIndexerAvalonia/Reading/TagMapImporter.cs
+++ b/GPTExporterIndexerAvalonia/Reading/TagMapImporter.cs
@@ -7,6 +7,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using GPTExporterIndexerAvalonia.ViewModels;
 using System.Text.Json;
+using GPTExporterIndexerAvalonia.Services;
 
 namespace GPTExporterIndexerAvalonia.Reading;
 
@@ -28,7 +29,10 @@ public static class TagMapImporter
                 if (arr != null)
                     entries.AddRange(arr);
             }
-            catch { }
+            catch (Exception ex)
+            {
+                DebugLogger.Log($"TagMapImporter: Failed to load JSON '{path}'. Error: {ex.Message}");
+            }
             return entries;
         }
 
@@ -59,7 +63,11 @@ public static class TagMapImporter
                 entries.Add(CreateEntry(record));
             }
         }
-        catch { }
+        catch (Exception ex)
+        {
+            DebugLogger.Log($"TagMapImporter: Failed to load CSV '{path}'. Error: {ex.Message}");
+            throw;
+        }
     }
 
     private static void LoadExcel(string path, List<TagMapEntry> entries)
@@ -99,7 +107,11 @@ public static class TagMapImporter
                 entries.Add(CreateEntry(record));
             }
         }
-        catch { }
+        catch (Exception ex)
+        {
+            DebugLogger.Log($"TagMapImporter: Failed to load Excel '{path}'. Error: {ex.Message}");
+            throw;
+        }
     }
 
     private static string? GetCellValue(Cell cell, SharedStringTable? shared)

--- a/GPTExporterIndexerAvalonia/Services/DialogService.cs
+++ b/GPTExporterIndexerAvalonia/Services/DialogService.cs
@@ -59,4 +59,25 @@ public class DialogService : IDialogService
 
         return result.FirstOrDefault()?.Path.LocalPath;
     }
+
+    public async Task ShowMessageAsync(string title, string message)
+    {
+        var mainWindow = GetMainWindow();
+        if (mainWindow is null) return;
+
+        var dialog = new Window
+        {
+            Title = title,
+            Width = 400,
+            Height = 200,
+            Content = new TextBlock
+            {
+                Text = message,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(20)
+            }
+        };
+
+        await dialog.ShowDialog(mainWindow);
+    }
 }

--- a/GPTExporterIndexerAvalonia/Services/IDialogService.cs
+++ b/GPTExporterIndexerAvalonia/Services/IDialogService.cs
@@ -19,4 +19,9 @@ public interface IDialogService
 
     // FIXED: Replaced obsolete FileDialogFilter with our new record type.
     Task<string?> ShowOpenFileDialogAsync(string title, FileFilter filter);
+
+    /// <summary>
+    /// Displays a simple message dialog to the user.
+    /// </summary>
+    Task ShowMessageAsync(string title, string message);
 }

--- a/GPTExporterIndexerAvalonia/ViewModels/TagMapViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/TagMapViewModel.cs
@@ -13,6 +13,7 @@ using System.Diagnostics;
 using GPTExporterIndexerAvalonia.Services;
 using System.Threading.Tasks;
 
+
 namespace GPTExporterIndexerAvalonia.ViewModels;
 public partial class TagMapEntry
 {
@@ -67,12 +68,12 @@ public partial class TagMapViewModel : ObservableObject
         if (!string.IsNullOrWhiteSpace(path))
         {
             FilePath = path;
-            Load(); // Call the existing Load method
+            await Load(); // Call the existing Load method
         }
     }
 
     [RelayCommand]
-    private void Load()
+    private async Task Load()
     {
         Documents.Clear();
         if (string.IsNullOrWhiteSpace(FilePath) || !File.Exists(FilePath))
@@ -96,7 +97,8 @@ public partial class TagMapViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Failed to load tag map: {ex.Message}");
+            DebugLogger.Log($"TagMapViewModel: Failed to load tag map '{FilePath}'. Error: {ex.Message}");
+            await _dialogService.ShowMessageAsync("Tag Map Load Error", $"Failed to load tag map:\n{ex.Message}");
         }
         FilterDocuments();
     }


### PR DESCRIPTION
## Summary
- log parse errors in TagMapImporter
- add `ShowMessageAsync` to `IDialogService` and implement dialog popup
- use new dialog to surface tag map load errors

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -nologo` *(fails: WebView namespaces missing)*

------
https://chatgpt.com/codex/tasks/task_e_687483a013a48332a839a0ffc857a086