### PR TITLE
Add crash logging

### DIFF
--- a/GPTExporterIndexerAvalonia/Program.cs
+++ b/GPTExporterIndexerAvalonia/Program.cs
@@ -4,6 +4,7 @@ using Avalonia;
 using Avalonia.ReactiveUI;
 using System;
 using Avalonia.WebView.Desktop;
+using GPTExporterIndexerAvalonia.Services;
 
 namespace GPTExporterIndexerAvalonia;
 
@@ -24,6 +25,7 @@ internal class Program
         catch (Exception ex) // <-- ADD THIS CATCH BLOCK
         {
             // This will now catch the crash and print the full error to the console
+            DebugLogger.Log(ex.ToString());
             Console.WriteLine("A FATAL ERROR OCCURRED:");
             Console.WriteLine(ex.ToString());
             Console.WriteLine("\nPress Enter to close...");


### PR DESCRIPTION
## Summary
- log crashes using `DebugLogger` in `Program.cs`

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release` *(fails: Unable to find suitable setter or adder for property Resources)*

------
https://chatgpt.com/codex/tasks/task_e_687489d3c3c48332a4c3700720b5bb52