### PR TITLE
Add logging to various catch blocks

### DIFF
--- a/CodexEngine/Parsing/EntryParserService.cs
+++ b/CodexEngine/Parsing/EntryParserService.cs
@@ -4,6 +4,7 @@ using CodexEngine.AmandaMapCore.Models;
 using System;
 using System.Globalization;
 using CodexEngine.Parsing;
+using CodexEngine.Services;
 
 namespace CodexEngine.Parsing
 {
@@ -71,7 +72,11 @@ namespace CodexEngine.Parsing
                     DateTime = date
                 };
             }
-            catch { return null; }
+            catch (Exception ex)
+            {
+                DebugLogger.Log(ex.Message);
+                return null;
+            }
         }
         
         private NumberedMapEntry? ParseNumberedEntry(string text, Match initialMatch)
@@ -95,7 +100,11 @@ namespace CodexEngine.Parsing
                     _ => new ThresholdEntry { Title = title, RawContent = text, Number = number, Date = date } 
                 };
             }
-            catch { return null; }
+            catch (Exception ex)
+            {
+                DebugLogger.Log(ex.Message);
+                return null;
+            }
         }
     }
 }

--- a/CodexEngine/Services/DebugLogger.cs
+++ b/CodexEngine/Services/DebugLogger.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+
+namespace CodexEngine.Services
+{
+    /// <summary>
+    /// A simple static logger to write debug messages to a file.
+    /// </summary>
+    public static class DebugLogger
+    {
+        private static readonly string LogPath = Path.Combine(AppContext.BaseDirectory, "debuglog.txt");
+        private static readonly object _lock = new object();
+
+        public static void Log(string message)
+        {
+            try
+            {
+                lock (_lock)
+                {
+                    File.AppendAllText(LogPath, $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} - {message}{Environment.NewLine}");
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Failed to write to log file: {ex.Message}");
+            }
+        }
+    }
+}

--- a/GPTExporterIndexerAvalonia/Helpers/AdvancedIndexer.cs
+++ b/GPTExporterIndexerAvalonia/Helpers/AdvancedIndexer.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using GPTExporterIndexerAvalonia.Services;
 
 namespace GPTExporterIndexerAvalonia.Helpers;
 
@@ -70,7 +71,10 @@ public static class AdvancedIndexer
                     }
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                DebugLogger.Log(ex.Message);
+            }
         }
 
         foreach (var file in Directory.EnumerateFiles(folderPath, "*", SearchOption.AllDirectories))
@@ -79,7 +83,15 @@ public static class AdvancedIndexer
             if (ext != ".txt" && ext != ".json" && ext != ".md")
                 continue;
             string text;
-            try { text = File.ReadAllText(file); } catch { continue; }
+            try
+            {
+                text = File.ReadAllText(file);
+            }
+            catch (Exception ex)
+            {
+                DebugLogger.Log(ex.Message);
+                continue;
+            }
 
             var relative = Path.GetRelativePath(folderPath, file);
             var detail = new FileDetail
@@ -163,7 +175,15 @@ public static class AdvancedIndexer
     {
         var snippets = new List<string>();
         string[] lines;
-        try { lines = File.ReadAllLines(filePath); } catch { return snippets; }
+        try
+        {
+            lines = File.ReadAllLines(filePath);
+        }
+        catch (Exception ex)
+        {
+            DebugLogger.Log(ex.Message);
+            return snippets;
+        }
         var lowerPhrase = phrase.ToLowerInvariant();
         for (int i = 0; i < lines.Length; i++)
         {

--- a/GPTExporterIndexerAvalonia/Helpers/SimpleIndexer.cs
+++ b/GPTExporterIndexerAvalonia/Helpers/SimpleIndexer.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text.Json;
 using System.Linq;
 using System.Text.RegularExpressions;
+using GPTExporterIndexerAvalonia.Services;
 
 namespace GPTExporterIndexerAvalonia.Helpers;
 
@@ -24,7 +25,15 @@ public static class SimpleIndexer
             if (ext != ".txt" && ext != ".json" && ext != ".md")
                 continue;
             string text;
-            try { text = File.ReadAllText(file); } catch { continue; }
+            try
+            {
+                text = File.ReadAllText(file);
+            }
+            catch (Exception ex)
+            {
+                DebugLogger.Log(ex.Message);
+                continue;
+            }
 
             foreach (Match m in TokenPattern.Matches(text))
             {


### PR DESCRIPTION
## Summary
- log exceptions in AdvancedIndexer and SimpleIndexer
- log exceptions in EntryParserService
- provide DebugLogger in core engine

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -clp:ErrorsOnly` *(fails: Avalonia error)*

------
https://chatgpt.com/codex/tasks/task_e_687489c70078833287ce2967c5f2501a