### PR TITLE
Add Clear Search and revert webview packages

### DIFF
--- a/GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
+++ b/GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj
@@ -24,9 +24,8 @@
       Additional controls and frameworks that enhance the UI.
     -->
     <PackageReference Include="Avalonia.HtmlRenderer" Version="11.0.0" />
-    <!-- Updated per Avalonia documentation. Use the new cross-platform
-         WebView package. -->
-    <PackageReference Include="Avalonia.Controls.WebView" Version="11.0.0" />
+    <!-- Revert to the widely available WebView.Avalonia packages -->
+    <PackageReference Include="WebView.Avalonia" Version="11.0.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 
     <!-- 
@@ -36,6 +35,8 @@
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
     <PackageReference Include="VersOne.Epub" Version="3.3.4" />
     <PackageReference Include="Docnet.Core" Version="2.6.0" />
+    <PackageReference Include="WebView.Avalonia.Desktop" Version="11.0.0" />
+    <PackageReference Include="MessageBox.Avalonia" Version="0.10.8" />
     <PackageReference Include="YamlDotNet" Version="15.1.2" />
     
     <!-- 

--- a/GPTExporterIndexerAvalonia/Program.cs
+++ b/GPTExporterIndexerAvalonia/Program.cs
@@ -3,7 +3,7 @@
 using Avalonia;
 using Avalonia.ReactiveUI;
 using System;
-using Avalonia.Controls.WebView;
+using Avalonia.WebView.Desktop;
 using GPTExporterIndexerAvalonia.Services;
 
 namespace GPTExporterIndexerAvalonia;

--- a/GPTExporterIndexerAvalonia/ViewModels/MainWindowViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/MainWindowViewModel.cs
@@ -203,6 +203,16 @@ public partial class MainWindowViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private void ClearSearch()
+    {
+        Results.Clear();
+        SelectedResult = null;
+        SelectedFileContent = null;
+        Status = "Search results cleared.";
+        DebugLogger.Log("MainWindowViewModel: Search results cleared by user.");
+    }
+
+    [RelayCommand]
     private void OpenSelected()
     {
         if (SelectedResult == null) return;

--- a/GPTExporterIndexerAvalonia/ViewModels/RitualBuilderViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/RitualBuilderViewModel.cs
@@ -2,7 +2,7 @@
 // REFACTORED
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Avalonia.Controls;
+using Avalonia.WebView;
 using System.Threading.Tasks;
 using System.IO;
 using System;
@@ -24,9 +24,9 @@ public partial class RitualBuilderViewModel : ObservableObject
     }
 
     /// <summary>
-    /// A reference to the NativeWebView control in the View. This should be set from the code-behind.
+    /// A reference to the WebView control in the View. This should be set from the code-behind.
     /// </summary>
-    public NativeWebView? Builder { get; set; }
+    public WebView? Builder { get; set; }
 
     /// <summary>
     /// Holds any error message that occurs during initialization so

--- a/GPTExporterIndexerAvalonia/Views/MainWindowView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/MainWindowView.axaml
@@ -38,6 +38,7 @@
                     <CheckBox Content="Case Sensitive" IsChecked="{Binding CaseSensitive}" />
                     <CheckBox Content="Fuzzy Match" IsChecked="{Binding UseFuzzy}" />
                     <Button Content="Search" Command="{Binding SearchCommand}" Classes="Primary"/>
+                    <Button Content="Clear Results" Command="{Binding ClearSearchCommand}" Margin="5,0,0,0"/>
                 </StackPanel>
             </StackPanel>
 

--- a/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml
@@ -2,14 +2,14 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="https://github.com/avaloniaui"
              xmlns:vm="clr-namespace:GPTExporterIndexerAvalonia.ViewModels"
-             xmlns:nwv="clr-namespace:Avalonia.Controls;assembly=Avalonia.Controls.WebView"
+            xmlns:wv="clr-namespace:Avalonia.WebView;assembly=Avalonia.WebView"
              x:Class="GPTExporterIndexerAvalonia.Views.RitualBuilderView"
              DataContext="{Binding RitualBuilderViewModel}">
     <Design.DataContext>
         <vm:RitualBuilderViewModel />
     </Design.DataContext>
     <Grid>
-        <nwv:NativeWebView Source="avares://GPTExporterIndexerAvalonia/WebAssets/ritual-builder.html" Name="Builder" />
+        <wv:WebView Url="avares://GPTExporterIndexerAvalonia/WebAssets/ritual-builder.html" Name="Builder" />
         <Button Content="Save" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="10" Command="{Binding SaveCommand}" />
         <TextBlock Text="{Binding ErrorMessage}" Background="#AA000000" Foreground="White"
                    HorizontalAlignment="Center" VerticalAlignment="Center"

--- a/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/RitualBuilderView.axaml.cs
@@ -1,5 +1,5 @@
 using Avalonia.Controls;
-using Avalonia.Controls;
+using Avalonia.WebView;
 using Avalonia.Markup.Xaml;
 using GPTExporterIndexerAvalonia.ViewModels;
 using GPTExporterIndexerAvalonia.Services;
@@ -32,18 +32,18 @@ namespace GPTExporterIndexerAvalonia.Views
             {
                 if (DataContext is RitualBuilderViewModel vm)
                 {
-                    var webView = this.FindControl<NativeWebView>("Builder");
+                    var webView = this.FindControl<WebView>("Builder");
                     if (webView is null)
                     {
-                        DebugLogger.Log("FATAL: Could not find NativeWebView control named 'Builder'.");
+                        DebugLogger.Log("FATAL: Could not find WebView control named 'Builder'.");
                         return;
                     }
 
-                    DebugLogger.Log("[RitualBuilderView] NativeWebView control found.");
+                    DebugLogger.Log("[RitualBuilderView] WebView control found.");
                     
                     // Assign the control to the ViewModel
                     vm.Builder = webView;
-                    DebugLogger.Log("[RitualBuilderView] Assigned NativeWebView to ViewModel. OnAttachedToVisualTree completed.");
+                    DebugLogger.Log("[RitualBuilderView] Assigned WebView to ViewModel. OnAttachedToVisualTree completed.");
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- add a `ClearSearch` command to wipe search results
- expose `Clear Results` button in the main window
- revert webview references back to `WebView.Avalonia`
- update ritual builder files to match the old control
- include `MessageBox.Avalonia` dependency

## Testing
- `dotnet restore CodexEngine/CodexEngine.csproj`
- `dotnet restore GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj` *(succeeds)*
- `dotnet build CodexEngine/CodexEngine.csproj -c Release`
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release` *(fails: unable to resolve WebView type)*

------
https://chatgpt.com/codex/tasks/task_e_687873517a4083328031bac315104eab