### PR TITLE
Add extension filter option to search

### DIFF
--- a/GPTExporterIndexerAvalonia/Helpers/AdvancedIndexer.cs
+++ b/GPTExporterIndexerAvalonia/Helpers/AdvancedIndexer.cs
@@ -22,6 +22,11 @@ public class SearchOptions
     public bool UseFuzzy { get; set; }
     public bool UseAnd { get; set; } = true;
     public int ContextLines { get; set; } = 1;
+    /// <summary>
+    /// Optional file extension filter like ".md" or ".txt".
+    /// When provided only matching files are returned.
+    /// </summary>
+    public string? ExtensionFilter { get; set; }
 }
 
 public static class AdvancedIndexer
@@ -158,6 +163,12 @@ public static class AdvancedIndexer
             yield break;
         foreach (var rel in result)
         {
+            if (!string.IsNullOrWhiteSpace(options.ExtensionFilter))
+            {
+                var ext = Path.GetExtension(rel);
+                if (!ext.Equals(options.ExtensionFilter, StringComparison.OrdinalIgnoreCase))
+                    continue;
+            }
             var fullPath = Path.Combine(Path.GetDirectoryName(indexPath)!, rel);
             var snippets = ExtractSnippets(fullPath, phrase, options.ContextLines);
             index.Files.TryGetValue(rel, out var detail);

--- a/GPTExporterIndexerAvalonia/ViewModels/MainWindowViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/MainWindowViewModel.cs
@@ -51,6 +51,7 @@ public partial class MainWindowViewModel : ObservableObject
     [ObservableProperty] private bool _useFuzzy;
     [ObservableProperty] private bool _useAnd = true;
     [ObservableProperty] private int _contextLines = 1;
+    [ObservableProperty] private string _extensionFilter = string.Empty;
     [ObservableProperty] private SearchResult? _selectedResult;
     [ObservableProperty] private string _selectedFile = string.Empty;
     [ObservableProperty] private string _parseFilePath = string.Empty;
@@ -184,7 +185,14 @@ public partial class MainWindowViewModel : ObservableObject
         Status = $"Searching for '{Query}'...";
         DebugLogger.Log($"MainWindowViewModel: Kicking off search for query: '{Query}'");
         Results.Clear();
-        var opts = new SearchOptions { CaseSensitive = CaseSensitive, UseFuzzy = UseFuzzy, UseAnd = UseAnd, ContextLines = ContextLines };
+        var opts = new SearchOptions
+        {
+            CaseSensitive = CaseSensitive,
+            UseFuzzy = UseFuzzy,
+            UseAnd = UseAnd,
+            ContextLines = ContextLines,
+            ExtensionFilter = string.IsNullOrWhiteSpace(ExtensionFilter) ? null : ExtensionFilter
+        };
         var indexPath = Path.Combine(IndexFolder, "index.json");
         if (!File.Exists(indexPath))
         {

--- a/GPTExporterIndexerAvalonia/Views/MainWindowView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/MainWindowView.axaml
@@ -37,6 +37,7 @@
                 <StackPanel Orientation="Horizontal" Spacing="10" HorizontalAlignment="Center">
                     <CheckBox Content="Case Sensitive" IsChecked="{Binding CaseSensitive}" />
                     <CheckBox Content="Fuzzy Match" IsChecked="{Binding UseFuzzy}" />
+                    <TextBox Width="60" Text="{Binding ExtensionFilter}" Watermark=".md"/>
                     <Button Content="Search" Command="{Binding SearchCommand}" Classes="Primary"/>
                     <Button Content="Clear Results" Command="{Binding ClearSearchCommand}" Margin="5,0,0,0"/>
                 </StackPanel>

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Searches the generated index with basic context snippets in the results.
 Provides advanced search options, including:
 Case sensitivity
 Fuzzy matching
+File extension filter
 AND/OR logic
 Allows you to open any matching file directly from the search results list.
 Includes a book reader tab for loading Markdown or text files.


### PR DESCRIPTION
## Summary
- implement `ExtensionFilter` in `SearchOptions`
- filter results by extension in `AdvancedIndexer.Search`
- expose new `ExtensionFilter` field in `MainWindowViewModel`
- add textbox in `MainWindowView` for user input
- document extension filter option in README

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release` *(fails: Unable to resolve type WebView)*
- `dotnet build CodexEngine/CodexEngine.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68792c1d0ecc833294eb22ccbd92a90e