### PR TITLE
Add theme import and export dialogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dist/
 
 allfiles.txt
 debuglog.txt
+dataset.json
+dataset.csv

--- a/GPTExporterIndexerAvalonia/Services/ControlPanel.cs
+++ b/GPTExporterIndexerAvalonia/Services/ControlPanel.cs
@@ -1,11 +1,16 @@
 using Avalonia;
 using Avalonia.Media;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Platform.Storage;
+using MessageBox.Avalonia;
 using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using ReactiveUI;
 
@@ -479,6 +484,45 @@ namespace GPTExporterIndexerAvalonia.Services
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
+        private Window? GetMainWindow()
+        {
+            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            {
+                return desktop.MainWindow;
+            }
+            return null;
+        }
+
+        private async Task ShowMessageAsync(string title, string message)
+        {
+            var window = GetMainWindow();
+            if (window is null)
+                return;
+
+            var msgBox = MessageBoxManager.GetMessageBoxStandardWindow(title, message);
+            await msgBox.ShowDialog(window);
+        }
+
+        private async Task<string?> ShowOpenFileDialogAsync(string title, string filterName, string[] extensions)
+        {
+            var window = GetMainWindow();
+            if (window is null) return null;
+
+            var fileType = new FilePickerFileType(filterName)
+            {
+                Patterns = extensions.Select(ext => $"*.{ext}").ToList()
+            };
+
+            var result = await window.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            {
+                Title = title,
+                AllowMultiple = false,
+                FileTypeFilter = new[] { fileType }
+            });
+
+            return result.FirstOrDefault()?.Path.LocalPath;
+        }
+
         private void ResetToDefaults()
         {
             SelectedTheme = "Magic";
@@ -492,7 +536,7 @@ namespace GPTExporterIndexerAvalonia.Services
             UseGradients = false;
         }
 
-        private void ExportTheme()
+        private async void ExportTheme()
         {
             try
             {
@@ -514,50 +558,41 @@ namespace GPTExporterIndexerAvalonia.Services
                 var filePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), fileName);
                 
                 File.WriteAllText(filePath, json);
-                
-                // TODO: Show success message
+
+                await ShowMessageAsync("Export Complete", $"Theme saved to {filePath}");
             }
             catch (Exception ex)
             {
-                // TODO: Show error message
+                await ShowMessageAsync("Export Error", ex.Message);
             }
         }
 
-        private void ImportTheme()
+        private async void ImportTheme()
         {
             try
             {
-                // TODO: Implement file picker dialog
-                // For now, just show a placeholder
-                // var dialog = new OpenFileDialog
-                // {
-                //     Title = "Import Theme",
-                //     Filters = new List<FileDialogFilter>
-                //     {
-                //         new FileDialogFilter { Name = "JSON Files", Extensions = new List<string> { "json" } }
-                //     }
-                // };
-                // 
-                // if (dialog.ShowAsync() == true)
-                // {
-                //     var json = File.ReadAllText(dialog.FileName);
-                //     var settings = JsonSerializer.Deserialize<ThemeSettings>(json);
-                //     
-                //     // Apply imported settings
-                //     SelectedTheme = settings.SelectedTheme ?? "Magic";
-                //     CustomBackground = ParseBrush(settings.CustomBackground) ?? Brushes.White;
-                //     CustomForeground = ParseBrush(settings.CustomForeground) ?? Brushes.Black;
-                //     CustomAccent = ParseBrush(settings.CustomAccent) ?? Brushes.Blue;
-                //     FontFamily = settings.FontFamily ?? "Segoe UI";
-                //     FontSize = settings.FontSize ?? 14;
-                //     EnableAnimations = settings.EnableAnimations ?? true;
-                //     CornerRadius = settings.CornerRadius ?? 8;
-                //     UseGradients = settings.UseGradients ?? false;
-                // }
+                var filePath = await ShowOpenFileDialogAsync("Import Theme", "JSON Files", new[] { "json" });
+                if (string.IsNullOrWhiteSpace(filePath))
+                    return;
+
+                var json = File.ReadAllText(filePath);
+                var settings = JsonSerializer.Deserialize<ThemeSettings>(json);
+
+                SelectedTheme = settings?.SelectedTheme ?? "Magic";
+                CustomBackground = ParseBrush(settings?.CustomBackground) ?? Brushes.White;
+                CustomForeground = ParseBrush(settings?.CustomForeground) ?? Brushes.Black;
+                CustomAccent = ParseBrush(settings?.CustomAccent) ?? Brushes.Blue;
+                FontFamily = settings?.FontFamily ?? "Segoe UI";
+                FontSize = settings?.FontSize ?? 14;
+                EnableAnimations = settings?.EnableAnimations ?? true;
+                CornerRadius = settings?.CornerRadius ?? 8;
+                UseGradients = settings?.UseGradients ?? false;
+
+                await ShowMessageAsync("Import Complete", $"Theme '{Path.GetFileName(filePath)}' loaded.");
             }
             catch (Exception ex)
             {
-                // TODO: Show error message
+                await ShowMessageAsync("Import Error", ex.Message);
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Provides a legacy tool tab to launch the original Python utility.
 - Quick preset buttons in the Settings panel for fast theme switching.
 - Optional "Hide Magic" toggle removes occult-themed controls when needed.
 - Real-time progress bar and status messages during indexing and TagMap generation.
+- Import and export custom themes as JSON files for easy sharing.
 
 Settings and Theming
 --------------------
@@ -41,12 +42,12 @@ Open the **Settings** dialog from the Control Panel to tweak fonts, colors, and 
 Select from preset **Light**, **Dark**, or **Magic** themes or build your own custom look.
 Dataset Builder
 ---------------
-Use `dataset_builder.py` to harvest paragraphs mentioning **AmandaMap**, **Phoenix Codex**, or **Whispered Flame**, plus numbered threshold entries. The script scans `.md`, `.txt`, and `.json` files. Run it with a folder and optional output file:
+Use `dataset_builder.py` to harvest paragraphs mentioning **AmandaMap**, **Phoenix Codex**, or **Whispered Flame**, plus numbered threshold entries. The script scans `.md`, `.txt`, and `.json` files and now offers optional CSV output.
 
 ```bash
-python dataset_builder.py <folder> --output dataset.json
+python dataset_builder.py <folder> --output dataset.json --csv
 ```
-The script writes a JSON array listing each file path, type, and text match.
+The script writes a JSON array listing each file path, type, and text match. If `--csv` is supplied, a companion `dataset.csv` is generated.
 
 TagMap Tab
 -----------

--- a/dataset_builder.py
+++ b/dataset_builder.py
@@ -2,12 +2,21 @@ import re
 import argparse
 import json
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, Optional
+from dataclasses import dataclass, asdict
 from modules.amandamap_parser import find_entries, find_thresholds
 from modules.json_scanner import scan_json_for_amandamap
 
 _PHX_RE = re.compile(r"(.*?(?:Phoenix Codex).*?)(?=\n\s*\n|$)", re.IGNORECASE | re.S)
 _WHISPER_RE = re.compile(r"(.*?(?:Whispered Flame|Flame Vow).*?)(?=\n\s*\n|$)", re.IGNORECASE | re.S)
+
+
+@dataclass
+class DatasetEntry:
+    file: str
+    type: str
+    text: str
+    number: Optional[int] = None
 
 def _next_paragraphs(paragraphs: List[str], i: int) -> str:
     parts = [paragraphs[i]]
@@ -33,54 +42,83 @@ def extract_whisper_entries(text: str) -> List[str]:
     return [m.group(1).strip() for m in _WHISPER_RE.finditer(text)]
 
 
-def scan_file(path: Path) -> List[Dict[str, str]]:
+def scan_file(path: Path) -> List[DatasetEntry]:
     text = path.read_text(encoding="utf-8", errors="ignore")
-    entries = []
+    entries: List[DatasetEntry] = []
     for num, seg in find_thresholds(text):
-        entries.append({
-            "file": str(path),
-            "type": "Threshold",
-            "number": num,
-            "text": seg,
-        })
+        entries.append(
+            DatasetEntry(
+                file=str(path),
+                type="Threshold",
+                text=seg,
+                number=num,
+            )
+        )
 
     for seg in find_entries(text):
-        entries.append({"file": str(path), "type": "AmandaMap", "text": seg})
+        entries.append(DatasetEntry(file=str(path), type="AmandaMap", text=seg))
 
     for seg in extract_keyword_segments(text, "AmandaMap"):
-        if seg not in [e["text"] for e in entries]:
-            entries.append({"file": str(path), "type": "AmandaMap", "text": seg})
+        if seg.lower() not in [e.text.lower() for e in entries]:
+            entries.append(DatasetEntry(file=str(path), type="AmandaMap", text=seg))
 
     for seg in extract_phoenix_entries(text):
-        entries.append({"file": str(path), "type": "PhoenixCodex", "text": seg})
+        entries.append(DatasetEntry(file=str(path), type="PhoenixCodex", text=seg))
 
     for seg in extract_whisper_entries(text):
-        entries.append({"file": str(path), "type": "WhisperedFlame", "text": seg})
+        entries.append(DatasetEntry(file=str(path), type="WhisperedFlame", text=seg))
     return entries
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Build dataset of AmandaMap and Phoenix Codex segments")
-    parser.add_argument("folder", help="Folder to scan recursively for .md, .txt and .json files")
-    parser.add_argument("--output", default="dataset.json", help="Output JSON file")
+    parser = argparse.ArgumentParser(
+        description="Build dataset of AmandaMap and Phoenix Codex segments"
+    )
+    parser.add_argument(
+        "folder", help="Folder to scan recursively for .md, .txt and .json files"
+    )
+    parser.add_argument(
+        "--output", default="dataset.json", help="Output JSON file"
+    )
+    parser.add_argument(
+        "--csv",
+        action="store_true",
+        help="Also output a CSV file (dataset.csv) alongside the JSON",
+    )
     args = parser.parse_args()
 
     folder = Path(args.folder)
-    entries: List[Dict[str, str]] = []
+    entries: List[DatasetEntry] = []
     for path in folder.rglob("*.md"):
+        print(f"Scanning {path}")
         entries.extend(scan_file(path))
     for path in folder.rglob("*.txt"):
+        print(f"Scanning {path}")
         entries.extend(scan_file(path))
     for path in folder.rglob("*.json"):
+        print(f"Scanning {path}")
         th, en = scan_json_for_amandamap(path)
         for num, seg in th:
-            entries.append({"file": str(path), "type": "Threshold", "number": num, "text": seg})
+            entries.append(
+                DatasetEntry(file=str(path), type="Threshold", text=seg, number=num)
+            )
         for seg in en:
-            entries.append({"file": str(path), "type": "AmandaMap", "text": seg})
+            entries.append(DatasetEntry(file=str(path), type="AmandaMap", text=seg))
 
     with open(args.output, "w", encoding="utf-8") as f:
-        json.dump(entries, f, indent=2)
+        json.dump([asdict(e) for e in entries], f, indent=2)
     print(f"Wrote {len(entries)} entries to {args.output}")
+
+    if args.csv:
+        import csv
+
+        csv_path = Path(args.output).with_suffix(".csv")
+        with csv_path.open("w", newline="", encoding="utf-8") as fcsv:
+            writer = csv.DictWriter(fcsv, fieldnames=["file", "type", "text", "number"])
+            writer.writeheader()
+            for e in entries:
+                writer.writerow(asdict(e))
+        print(f"Wrote CSV output to {csv_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement message dialogs in ControlPanel
- support importing theme JSON via file picker
- document theme import/export in README

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release`
- `python -m py_compile dataset_builder.py`
- `python dataset_builder.py --help`


------
https://chatgpt.com/codex/tasks/task_e_687c3bcfb438833283d56b23d650eb3e