### PR TITLE
Add dialogs and timeline editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dist/
 
 allfiles.txt
 debuglog.txt
+dataset.json
+dataset.csv

--- a/GPTExporterIndexerAvalonia/Services/DialogService.cs
+++ b/GPTExporterIndexerAvalonia/Services/DialogService.cs
@@ -71,4 +71,14 @@ public class DialogService : IDialogService
             .GetMessageBoxStandardWindow(title, message);
         await msgBox.ShowDialog(mainWindow);
     }
+
+    public async Task<string?> ShowInputDialogAsync(string title, string prompt, string defaultText = "")
+    {
+        var mainWindow = GetMainWindow();
+        if (mainWindow is null)
+            return null;
+
+        var dialog = new Views.Dialogs.InputDialog(title, prompt, defaultText);
+        return await dialog.ShowDialog<string?>(mainWindow);
+    }
 }

--- a/GPTExporterIndexerAvalonia/Services/IDialogService.cs
+++ b/GPTExporterIndexerAvalonia/Services/IDialogService.cs
@@ -26,4 +26,12 @@ public interface IDialogService
     /// <param name="title">The title of the message box.</param>
     /// <param name="message">The message content.</param>
     Task ShowMessageAsync(string title, string message);
+
+    /// <summary>
+    /// Prompt the user for a single line of text.
+    /// </summary>
+    /// <param name="title">Dialog title.</param>
+    /// <param name="prompt">Prompt message.</param>
+    /// <param name="defaultText">Optional default input value.</param>
+    Task<string?> ShowInputDialogAsync(string title, string prompt, string defaultText = "");
 }

--- a/GPTExporterIndexerAvalonia/ViewModels/AmandaMapTimelineViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/AmandaMapTimelineViewModel.cs
@@ -4,6 +4,7 @@ using CodexEngine.AmandaMapCore.Models;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
 using GPTExporterIndexerAvalonia.ViewModels.Messages;
 
 namespace GPTExporterIndexerAvalonia.ViewModels;
@@ -203,19 +204,26 @@ public partial class AmandaMapTimelineViewModel : ObservableObject, IRecipient<A
     /// View entry details
     /// </summary>
     [CommunityToolkit.Mvvm.Input.RelayCommand]
-    private void ViewEntryDetails(NumberedMapEntry entry)
+    private async Task ViewEntryDetailsAsync(NumberedMapEntry entry)
     {
-        // TODO: Implement entry details view
-        // This could open a dialog or navigate to the AmandaMap tab
+        if (entry is null) return;
+        var vm = new EntryDetailViewModel();
+        vm.Load(entry);
+        var window = new Views.Dialogs.EntryDetailWindow { DataContext = vm, Title = $"Entry #{entry.Number}" };
+        if (Avalonia.Application.Current?.ApplicationLifetime is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            await window.ShowDialog(desktop.MainWindow);
+        }
     }
 
     /// <summary>
     /// Edit entry
     /// </summary>
     [CommunityToolkit.Mvvm.Input.RelayCommand]
-    private void EditEntry(NumberedMapEntry entry)
+    private async Task EditEntryAsync(NumberedMapEntry entry)
     {
-        // TODO: Implement entry editing
-        // This could open an edit dialog
+        if (entry is null) return;
+        await ViewEntryDetailsAsync(entry);
+        Refresh();
     }
-} 
+}

--- a/GPTExporterIndexerAvalonia/ViewModels/EntryDetailViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/EntryDetailViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CodexEngine.PhoenixEntries;
+using CodexEngine.AmandaMapCore.Models;
 using System;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
@@ -34,6 +35,7 @@ public partial class EntryDetailViewModel : ObservableObject
     private bool _visibleToAmanda;
 
     public EntryBase? BoundEntry { get; private set; }
+    public NumberedMapEntry? BoundAmandaEntry { get; private set; }
 
     public void Load(EntryBase entry)
     {
@@ -48,6 +50,19 @@ public partial class EntryDetailViewModel : ObservableObject
         Status = entry.Status;
         MirrorToAmandaMap = entry.MirrorToAmandaMap;
         VisibleToAmanda = entry.VisibleToAmanda;
+    }
+
+    public void Load(NumberedMapEntry entry)
+    {
+        BoundAmandaEntry = entry;
+        Title = entry.Title;
+        Date = entry.Date;
+        Description = entry.RawContent;
+        FieldEncoding = new();
+        Tags.Clear();
+        Status = EntryStatus.Unknown;
+        MirrorToAmandaMap = false;
+        VisibleToAmanda = false;
     }
 
     [RelayCommand]
@@ -65,14 +80,22 @@ public partial class EntryDetailViewModel : ObservableObject
     [RelayCommand]
     private void Save()
     {
-        if (BoundEntry is null) return;
-        BoundEntry.Title = Title;
-        BoundEntry.Date = Date;
-        BoundEntry.Description = Description;
-        BoundEntry.FieldEncoding = FieldEncoding;
-        BoundEntry.Tags = new List<string>(Tags);
-        BoundEntry.Status = Status;
-        BoundEntry.MirrorToAmandaMap = MirrorToAmandaMap;
-        BoundEntry.VisibleToAmanda = VisibleToAmanda;
+        if (BoundEntry is not null)
+        {
+            BoundEntry.Title = Title;
+            BoundEntry.Date = Date;
+            BoundEntry.Description = Description;
+            BoundEntry.FieldEncoding = FieldEncoding;
+            BoundEntry.Tags = new List<string>(Tags);
+            BoundEntry.Status = Status;
+            BoundEntry.MirrorToAmandaMap = MirrorToAmandaMap;
+            BoundEntry.VisibleToAmanda = VisibleToAmanda;
+        }
+        if (BoundAmandaEntry is not null)
+        {
+            BoundAmandaEntry.Title = Title;
+            BoundAmandaEntry.Date = Date;
+            BoundAmandaEntry.RawContent = Description;
+        }
     }
 }

--- a/GPTExporterIndexerAvalonia/ViewModels/SettingsViewModel.cs
+++ b/GPTExporterIndexerAvalonia/ViewModels/SettingsViewModel.cs
@@ -12,6 +12,7 @@ namespace GPTExporterIndexerAvalonia.ViewModels;
 public partial class SettingsViewModel : ObservableObject
 {
     private readonly ISettingsService _settingsService;
+    private readonly IDialogService _dialogService;
 
     [ObservableProperty]
     private AppSettings _settings;
@@ -66,9 +67,10 @@ public partial class SettingsViewModel : ObservableObject
         "#BB8FCE"  // Lavender
     };
 
-    public SettingsViewModel(ISettingsService settingsService)
+    public SettingsViewModel(ISettingsService settingsService, IDialogService dialogService)
     {
         _settingsService = settingsService;
+        _dialogService = dialogService;
         _settings = _settingsService.Settings;
         _moveCopyDefaultAction = _settings.MoveCopyDefaultAction;
         _overwriteBehavior = _settings.OverwriteBehavior;
@@ -146,13 +148,12 @@ public partial class SettingsViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void AddHiddenCategory()
+    private async Task AddHiddenCategoryAsync()
     {
-        // This would open a dialog to add a new hidden category
-        // For now, we'll just add a placeholder
-        if (!Settings.HiddenCategories.Contains("New Category"))
+        var result = await _dialogService.ShowInputDialogAsync("Add Hidden Category", "Category name:");
+        if (!string.IsNullOrWhiteSpace(result) && !Settings.HiddenCategories.Contains(result))
         {
-            Settings.HiddenCategories.Add("New Category");
+            Settings.HiddenCategories.Add(result);
             IsDirty = true;
         }
     }
@@ -168,12 +169,12 @@ public partial class SettingsViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void AddHiddenTag()
+    private async Task AddHiddenTagAsync()
     {
-        // This would open a dialog to add a new hidden tag
-        if (!Settings.HiddenTags.Contains("New Tag"))
+        var result = await _dialogService.ShowInputDialogAsync("Add Hidden Tag", "Tag name:");
+        if (!string.IsNullOrWhiteSpace(result) && !Settings.HiddenTags.Contains(result))
         {
-            Settings.HiddenTags.Add("New Tag");
+            Settings.HiddenTags.Add(result);
             IsDirty = true;
         }
     }
@@ -189,14 +190,16 @@ public partial class SettingsViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void AddMagicTermReplacement()
+    private async Task AddMagicTermReplacementAsync()
     {
-        // This would open a dialog to add a new magic term replacement
-        if (!Settings.MagicTermReplacements.ContainsKey("new term"))
-        {
-            Settings.MagicTermReplacements.Add("new term", "replacement");
-            IsDirty = true;
-        }
+        var term = await _dialogService.ShowInputDialogAsync("Add Replacement", "Magic term:");
+        if (string.IsNullOrWhiteSpace(term))
+            return;
+        var replacement = await _dialogService.ShowInputDialogAsync("Replacement", "Replace with:");
+        if (string.IsNullOrWhiteSpace(replacement))
+            return;
+        Settings.MagicTermReplacements[term] = replacement;
+        IsDirty = true;
     }
 
     [RelayCommand]

--- a/GPTExporterIndexerAvalonia/Views/Dialogs/EntryDetailWindow.axaml
+++ b/GPTExporterIndexerAvalonia/Views/Dialogs/EntryDetailWindow.axaml
@@ -1,0 +1,8 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:views="clr-namespace:GPTExporterIndexerAvalonia.Views"
+        x:Class="GPTExporterIndexerAvalonia.Views.Dialogs.EntryDetailWindow"
+        Width="450" Height="600"
+        WindowStartupLocation="CenterOwner">
+    <views:EntryDetailView/>
+</Window>

--- a/GPTExporterIndexerAvalonia/Views/Dialogs/EntryDetailWindow.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/Dialogs/EntryDetailWindow.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace GPTExporterIndexerAvalonia.Views.Dialogs;
+
+public partial class EntryDetailWindow : Window
+{
+    public EntryDetailWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/GPTExporterIndexerAvalonia/Views/Dialogs/InputDialog.axaml
+++ b/GPTExporterIndexerAvalonia/Views/Dialogs/InputDialog.axaml
@@ -1,0 +1,14 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="GPTExporterIndexerAvalonia.Views.Dialogs.InputDialog"
+        Width="350" Height="150"
+        WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="10" Spacing="8">
+        <TextBlock x:Name="PromptBlock" Text="Prompt"/>
+        <TextBox x:Name="InputBox"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="6" Margin="0,10,0,0">
+            <Button Content="Cancel" IsCancel="True" Click="OnCancel"/>
+            <Button Content="OK" IsDefault="True" Click="OnOk"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/GPTExporterIndexerAvalonia/Views/Dialogs/InputDialog.axaml.cs
+++ b/GPTExporterIndexerAvalonia/Views/Dialogs/InputDialog.axaml.cs
@@ -1,0 +1,35 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+
+namespace GPTExporterIndexerAvalonia.Views.Dialogs;
+
+public partial class InputDialog : Window
+{
+    public InputDialog()
+    {
+        InitializeComponent();
+    }
+
+    public InputDialog(string title, string prompt, string defaultText = "") : this()
+    {
+        Title = title;
+        this.FindControl<TextBlock>("PromptBlock").Text = prompt;
+        this.FindControl<TextBox>("InputBox").Text = defaultText;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private void OnOk(object? sender, RoutedEventArgs e)
+    {
+        Close(this.FindControl<TextBox>("InputBox").Text);
+    }
+
+    private void OnCancel(object? sender, RoutedEventArgs e)
+    {
+        Close(null);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Provides a legacy tool tab to launch the original Python utility.
 - Quick preset buttons in the Settings panel for fast theme switching.
 - Optional "Hide Magic" toggle removes occult-themed controls when needed.
 - Real-time progress bar and status messages during indexing and TagMap generation.
+- Import and export custom themes as JSON files for easy sharing.
 
 Settings and Theming
 --------------------
@@ -41,12 +42,12 @@ Open the **Settings** dialog from the Control Panel to tweak fonts, colors, and 
 Select from preset **Light**, **Dark**, or **Magic** themes or build your own custom look.
 Dataset Builder
 ---------------
-Use `dataset_builder.py` to harvest paragraphs mentioning **AmandaMap**, **Phoenix Codex**, or **Whispered Flame**, plus numbered threshold entries. The script scans `.md`, `.txt`, and `.json` files. Run it with a folder and optional output file:
+Use `dataset_builder.py` to harvest paragraphs mentioning **AmandaMap**, **Phoenix Codex**, or **Whispered Flame**, plus numbered threshold entries. The script scans `.md`, `.txt`, and `.json` files and now offers optional CSV output.
 
 ```bash
-python dataset_builder.py <folder> --output dataset.json
+python dataset_builder.py <folder> --output dataset.json --csv
 ```
-The script writes a JSON array listing each file path, type, and text match.
+The script writes a JSON array listing each file path, type, and text match. If `--csv` is supplied, a companion `dataset.csv` is generated.
 
 TagMap Tab
 -----------

--- a/dataset_builder.py
+++ b/dataset_builder.py
@@ -2,12 +2,21 @@ import re
 import argparse
 import json
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, Optional
+from dataclasses import dataclass, asdict
 from modules.amandamap_parser import find_entries, find_thresholds
 from modules.json_scanner import scan_json_for_amandamap
 
 _PHX_RE = re.compile(r"(.*?(?:Phoenix Codex).*?)(?=\n\s*\n|$)", re.IGNORECASE | re.S)
 _WHISPER_RE = re.compile(r"(.*?(?:Whispered Flame|Flame Vow).*?)(?=\n\s*\n|$)", re.IGNORECASE | re.S)
+
+
+@dataclass
+class DatasetEntry:
+    file: str
+    type: str
+    text: str
+    number: Optional[int] = None
 
 def _next_paragraphs(paragraphs: List[str], i: int) -> str:
     parts = [paragraphs[i]]
@@ -33,54 +42,83 @@ def extract_whisper_entries(text: str) -> List[str]:
     return [m.group(1).strip() for m in _WHISPER_RE.finditer(text)]
 
 
-def scan_file(path: Path) -> List[Dict[str, str]]:
+def scan_file(path: Path) -> List[DatasetEntry]:
     text = path.read_text(encoding="utf-8", errors="ignore")
-    entries = []
+    entries: List[DatasetEntry] = []
     for num, seg in find_thresholds(text):
-        entries.append({
-            "file": str(path),
-            "type": "Threshold",
-            "number": num,
-            "text": seg,
-        })
+        entries.append(
+            DatasetEntry(
+                file=str(path),
+                type="Threshold",
+                text=seg,
+                number=num,
+            )
+        )
 
     for seg in find_entries(text):
-        entries.append({"file": str(path), "type": "AmandaMap", "text": seg})
+        entries.append(DatasetEntry(file=str(path), type="AmandaMap", text=seg))
 
     for seg in extract_keyword_segments(text, "AmandaMap"):
-        if seg not in [e["text"] for e in entries]:
-            entries.append({"file": str(path), "type": "AmandaMap", "text": seg})
+        if seg.lower() not in [e.text.lower() for e in entries]:
+            entries.append(DatasetEntry(file=str(path), type="AmandaMap", text=seg))
 
     for seg in extract_phoenix_entries(text):
-        entries.append({"file": str(path), "type": "PhoenixCodex", "text": seg})
+        entries.append(DatasetEntry(file=str(path), type="PhoenixCodex", text=seg))
 
     for seg in extract_whisper_entries(text):
-        entries.append({"file": str(path), "type": "WhisperedFlame", "text": seg})
+        entries.append(DatasetEntry(file=str(path), type="WhisperedFlame", text=seg))
     return entries
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Build dataset of AmandaMap and Phoenix Codex segments")
-    parser.add_argument("folder", help="Folder to scan recursively for .md, .txt and .json files")
-    parser.add_argument("--output", default="dataset.json", help="Output JSON file")
+    parser = argparse.ArgumentParser(
+        description="Build dataset of AmandaMap and Phoenix Codex segments"
+    )
+    parser.add_argument(
+        "folder", help="Folder to scan recursively for .md, .txt and .json files"
+    )
+    parser.add_argument(
+        "--output", default="dataset.json", help="Output JSON file"
+    )
+    parser.add_argument(
+        "--csv",
+        action="store_true",
+        help="Also output a CSV file (dataset.csv) alongside the JSON",
+    )
     args = parser.parse_args()
 
     folder = Path(args.folder)
-    entries: List[Dict[str, str]] = []
+    entries: List[DatasetEntry] = []
     for path in folder.rglob("*.md"):
+        print(f"Scanning {path}")
         entries.extend(scan_file(path))
     for path in folder.rglob("*.txt"):
+        print(f"Scanning {path}")
         entries.extend(scan_file(path))
     for path in folder.rglob("*.json"):
+        print(f"Scanning {path}")
         th, en = scan_json_for_amandamap(path)
         for num, seg in th:
-            entries.append({"file": str(path), "type": "Threshold", "number": num, "text": seg})
+            entries.append(
+                DatasetEntry(file=str(path), type="Threshold", text=seg, number=num)
+            )
         for seg in en:
-            entries.append({"file": str(path), "type": "AmandaMap", "text": seg})
+            entries.append(DatasetEntry(file=str(path), type="AmandaMap", text=seg))
 
     with open(args.output, "w", encoding="utf-8") as f:
-        json.dump(entries, f, indent=2)
+        json.dump([asdict(e) for e in entries], f, indent=2)
     print(f"Wrote {len(entries)} entries to {args.output}")
+
+    if args.csv:
+        import csv
+
+        csv_path = Path(args.output).with_suffix(".csv")
+        with csv_path.open("w", newline="", encoding="utf-8") as fcsv:
+            writer = csv.DictWriter(fcsv, fieldnames=["file", "type", "text", "number"])
+            writer.writeheader()
+            for e in entries:
+                writer.writerow(asdict(e))
+        print(f"Wrote CSV output to {csv_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add generic `InputDialog` and `EntryDetailWindow`
- extend `IDialogService` with `ShowInputDialogAsync`
- enable adding hidden categories, tags, and replacements via dialogs
- implement view/edit support in AmandaMap timeline
- allow `EntryDetailViewModel` to load AmandaMap entries

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj -c Release`
- `python -m py_compile dataset_builder.py`
- `python dataset_builder.py --help`


------
https://chatgpt.com/codex/tasks/task_e_687c3bcfb438833283d56b23d650eb3e