### PR TITLE
feat: stream dataset files sequentially

### DIFF
--- a/enhanced_dataset_gui.py
+++ b/enhanced_dataset_gui.py
@@ -512,11 +512,10 @@ Total Samples: {summary.get('total_samples', 0)}
                 self.message_queue.put({'type': 'finished'})
                 return
             
-            # Process files in RAM
-            self.message_queue.put({'type': 'log', 'text': "💾 Loading files into RAM for processing..."})
-            
-            # Use RAM-based processing
-            amandamap_entries, phoenix_entries = self.file_processor.process_files_in_ram(all_files)
+            # Process files sequentially to avoid high RAM usage
+            self.message_queue.put({'type': 'log', 'text': "📄 Processing files sequentially..."})
+
+            amandamap_entries, phoenix_entries = self.file_processor.process_files_streaming(all_files)
             
             self.message_queue.put({'type': 'log', 'text': f"✅ Processing complete!"})
             self.message_queue.put({'type': 'log', 'text': f"🗺️ AmandaMap entries found: {len(amandamap_entries)}"})


### PR DESCRIPTION
## Summary
- process dataset files sequentially rather than loading them all into RAM
- release each file from memory after processing
- update GUI to use new streaming method and log sequential processing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688db30605ac83328089749195b854d5