### PR TITLE
fix: stream dataset files directly to disk

### DIFF
--- a/enhanced_dataset_builder.py
+++ b/enhanced_dataset_builder.py
@@ -1057,58 +1057,96 @@ class FileProcessor:
     def extract_whisper_entries(self, text: str) -> List[str]:
         return [m.group(1).strip() for m in _WHISPER_RE.finditer(text)]
     
-    def process_files_in_ram(self, file_paths: List[Path]) -> Tuple[List[DatasetEntry], List[DatasetEntry]]:
-        """Process files in RAM and return separate AmandaMap and Phoenix Codex entries."""
-        all_entries = []
-        
-        # Load all files into RAM
-        ram_contents = {}
+    def process_files_streaming(
+        self,
+        file_paths: List[Path],
+        amandamap_file: str = "amandamapexportfile.json",
+        phoenix_file: str = "phoenixcodexexport.json",
+    ) -> Dict[str, int]:
+        """Process files sequentially, exporting results as we go.
+
+        This avoids building huge in-memory lists that previously stalled
+        processing after ~30 files.  Instead, entries are written to disk
+        immediately and only lightweight counters are kept in RAM.
+        """
+
+        # Track counts for final reporting
+        entry_counts: Dict[str, int] = defaultdict(int)
+
         for file_path in file_paths:
             should_process, reason = self.should_process_file(file_path)
             if not should_process:
                 print(f"⏭️ Skipping {file_path.name}: {reason}")
                 continue
-            
-            try:
-                content = self.read_file_optimized(file_path)
-                ram_contents[file_path] = content
-                print(f"📖 Loaded {file_path.name} into RAM ({len(content)} chars)")
-            except Exception as e:
-                print(f"❌ Error loading {file_path}: {e}")
-        
-        # Process all content in RAM
-        for file_path, content in ram_contents.items():
+
+            content = ""
             try:
                 start_time = time.time()
+                content = self.read_file_optimized(file_path)
                 file_entries = self.scan_file_enhanced(file_path, content)
-                
-                # Add processing metrics
+
                 processing_time = time.time() - start_time
                 memory_usage = self.memory_manager.get_memory_usage()
-                
+
+                # Temporary holders for this file's results so we can flush
+                amandamap_batch: List[Dict[str, Any]] = []
+                phoenix_batch: List[Dict[str, Any]] = []
+
                 for entry in file_entries:
                     entry.processing_time = processing_time
                     entry.memory_usage = int(memory_usage * 1024 * 1024)
-                
-                all_entries.extend(file_entries)
-                
+
+                    entry_counts[entry.type] += 1
+
+                    if (
+                        entry.is_amanda_related
+                        or entry.type.lower().startswith("amandamap")
+                        or entry.type.lower()
+                        in ["threshold", "fieldpulse", "whisperedflame", "flamevow"]
+                    ):
+                        amandamap_batch.append(asdict(entry))
+                        entry_counts["AmandaMap"] += 1
+                    elif entry.is_phoenix_codex or entry.type.lower().startswith("phoenix"):
+                        phoenix_batch.append(asdict(entry))
+                        entry_counts["PhoenixCodex"] += 1
+
+                # Immediately write batches to disk to free RAM
+                if amandamap_batch:
+                    self.append_entries_to_file(amandamap_batch, amandamap_file)
+                if phoenix_batch:
+                    self.append_entries_to_file(phoenix_batch, phoenix_file)
+
                 if self.verbose_mode:
-                    print(f"✅ Processed {file_path.name}: {len(file_entries)} entries")
-                
+                    print(
+                        f"✅ Processed {file_path.name}: {len(file_entries)} entries"
+                    )
+
             except Exception as e:
                 print(f"❌ Error processing {file_path}: {e}")
-        
-        # Separate AmandaMap and Phoenix Codex entries
-        amandamap_entries = []
-        phoenix_entries = []
-        
-        for entry in all_entries:
-            if entry.is_amanda_related or entry.type.lower().startswith('amandamap') or entry.type.lower() in ['threshold', 'fieldpulse', 'whisperedflame', 'flamevow']:
-                amandamap_entries.append(entry)
-            elif entry.is_phoenix_codex or entry.type.lower().startswith('phoenix'):
-                phoenix_entries.append(entry)
-        
-        return amandamap_entries, phoenix_entries
+            finally:
+                if self.settings.enable_file_cache:
+                    self.file_cache.pop(str(file_path), None)
+                del content
+                self.memory_manager.force_garbage_collection()
+
+        return dict(entry_counts)
+
+    def append_entries_to_file(self, entries: List[Dict[str, Any]], file_path: str) -> None:
+        """Append entries to a JSON file, creating it if needed."""
+        path = Path(file_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        existing: List[Dict[str, Any]] = []
+        if path.exists():
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    existing = json.load(f)
+            except Exception:
+                existing = []
+
+        existing.extend(entries)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(existing, f, indent=2, ensure_ascii=False)
     
     def export_to_separate_files(self, amandamap_entries: List[DatasetEntry], phoenix_entries: List[DatasetEntry], 
                                 amandamap_file: str = "amandamapexportfile.json", 


### PR DESCRIPTION
## Summary
- write each file's AmandaMap and Phoenix Codex entries straight to disk while streaming, keeping only counters in memory
- update GUI to use count-based streaming workflow and report final totals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688db30605ac83328089749195b854d5