### PR TITLE
refactor: compact file parser controls

### DIFF
--- a/GPTExporterIndexerAvalonia/Views/MainWindowView.axaml
+++ b/GPTExporterIndexerAvalonia/Views/MainWindowView.axaml
@@ -31,15 +31,21 @@
                 <Border Classes="Card" Margin="0,5,0,0">
                     <StackPanel Spacing="5">
                         <TextBlock Text="File Parser" Classes="Header"/>
-                        <Button Content="Parse a File..." Command="{Binding ParseFileCommand}"/>
-                        <Button Content="Extract AmandaMap Entries..." Command="{Binding ExtractAmandaMapEntriesCommand}" Classes="Primary"/>
-                        <Button Content="Extract Phoenix Codex Entries..." Command="{Binding ExtractPhoenixCodexEntriesCommand}" Classes="Primary"/>
-                        <Button Content="Analyze Folder..." Command="{Binding AnalyzeFolderCommand}"/>
-                        <TextBlock Text="TagMap Tools" Classes="Header" Margin="0,10,0,0"/>
-                        <Button Content="Generate TagMap..." Command="{Binding GenerateTagMapCommand}" Classes="Primary"/>
-                        <Button Content="Update TagMap..." Command="{Binding UpdateTagMapCommand}"/>
-                        <TextBlock Text="Chat File Management" Classes="Header" Margin="0,10,0,0"/>
-                        <Button Content="Manage Chat Files..." Command="{Binding ManageChatFilesCommand}" Classes="Primary"/>
+                        <StackPanel Orientation="Horizontal" Spacing="5">
+                            <Button Content="Parse a File..." Command="{Binding ParseFileCommand}"/>
+                            <Button Content="Extract AmandaMap Entries..." Command="{Binding ExtractAmandaMapEntriesCommand}" Classes="Primary"/>
+                            <Button Content="Extract Phoenix Codex Entries..." Command="{Binding ExtractPhoenixCodexEntriesCommand}" Classes="Primary"/>
+                            <Button Content="Analyze Folder..." Command="{Binding AnalyzeFolderCommand}"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="5" Margin="0,10,0,0">
+                            <TextBlock Text="TagMap Tools" Classes="Header" Margin="0" VerticalAlignment="Center"/>
+                            <Button Content="Generate TagMap..." Command="{Binding GenerateTagMapCommand}" Classes="Primary"/>
+                            <Button Content="Update TagMap..." Command="{Binding UpdateTagMapCommand}"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="5" Margin="0,10,0,0">
+                            <TextBlock Text="Chat File Management" Classes="Header" Margin="0" VerticalAlignment="Center"/>
+                            <Button Content="Manage Chat Files..." Command="{Binding ManageChatFilesCommand}" Classes="Primary"/>
+                        </StackPanel>
                         
                         <!-- Progress Section -->
                         <Border Classes="Card" Margin="0,10,0,0" IsVisible="{Binding IsOperationInProgress}">


### PR DESCRIPTION
## Summary
- arrange File Parser buttons in a single row
- place TagMap Tools and Chat File Management buttons inline with their labels
- free up vertical space for search results

## Testing
- `dotnet build GPTExporterIndexerAvalonia/GPTExporterIndexerAvalonia.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6892a84cafbc833294b3c90b21f2bd0a